### PR TITLE
Fix locale dependent build issue (minor)

### DIFF
--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -1,6 +1,10 @@
 development:
   adapter: postgresql
   database: usgc_dev
+  encoding: utf8
+  ctype: en_US.utf8
+  collation: en_US.utf8
+  template: template0
   pool: 5
   timeout: 5000
 
@@ -10,6 +14,10 @@ development:
 test:
   adapter: postgresql
   database: usgc_test
+  encoding: utf8
+  ctype: en_US.utf8
+  collation: en_US.utf8
+  template: template0
   min_messages: WARNING
   pool: 5
   timeout: 5000


### PR DESCRIPTION
~~  Short version:

We are relying on rails' default encoding of utf8 when creating our postgres databases. We should specify utf8 specifically, along with the locale settings, rather than rely on the defaults.

I had a problem with "bundle exec rake db:setup" because my virtual machine's locale is (probably) different than yours. Mine is en_US, I'm guessing you have en_US.utf8.

~~ Longer version:

When I ran "bundle exec rake db:setup" (specifically, this is during the db:create part of db:setup), I received the following error:

---

PG::InvalidParameterValue: ERROR:  encoding "UTF8" does not match locale "en_US"
DETAIL:  The chosen LC_CTYPE setting requires encoding "LATIN1".
: CREATE DATABASE "usgc_dev" ENCODING = 'utf8'
... snipped ...
## Couldn't create database for {"adapter"=>"postgresql", "database"=>"usgc_dev", "pool"=>5, "timeout"=>5000}

Rails defaults to utf8 encoding when creating a database with postgres (http://bit.ly/1cgE1LZ) if the encoding isn't specified in database.yml. When a new database is created, what postgres actually does behind the scenes is copy an existing database called "template1" (http://bit.ly/1cMuNDL), along with it's encoding, locale, and other settings. template1's locale is set based on when postgres was originally installed. It uses the install users's locale settings. Mine happen to be en_US, so on my install of postgresql 9.2, the encoding and locale of template1 are latin1/iso-8859-1 and en_US.

Rails is asking postgres to create a database with an encoding of utf8 and doesn't mention anything about the locale settings, so postgres tries to copy over the original template1 settings of en_US. Unfortunately this causes the above error since en_US doesn't play nicely with utf8.

This code change to make sure the database creation is forced to use en_US.utf8 for the locale settings (LC_CTYPE and LC_COLLATE). The other entry in the database.yml is the template. Postgres documentation says to be able to change the locale settings you need to copy from template0 rather than template1, so that's what it does.

If you have any other questions feel free to ask.

Forcing utf8 by adding the following entries:
- encoding: utf8
- ctype: en_US.utf8
- collation: en_US.utf8
- template: template0
