### PR TITLE
Fixes routing error after selecting Submit in Settings

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Gocongress::Application.routes.draw do
       constraints :year => /\d+/ do
 
         get 'edit' => 'years#edit', :as => :edit_year
-        put '' => 'years#update', :as => :update_year
+        patch '' => 'years#update', :as => :update_year
 
         get 'costs' => 'plan_categories#index'
 


### PR DESCRIPTION
Selecting Submit in Settings results in a routing error:

No route matches [PATCH] "/2014"

Replacing `put` with `patch` in

``` ruby
put '' => 'years#update', :as => :update_year
```

seems to fix the problem.
