### PR TITLE
Fixes routing error after attempting to register

### DIFF
--- a/app/views/sign_ups/new.html.haml
+++ b/app/views/sign_ups/new.html.haml
@@ -35,7 +35,7 @@
       In that case, please
       = link_to "sign in.", new_user_session_path
 
-  = form_for(resource, :as => resource_name, :url => registration_path(resource_name)) do |f|
+  = form_for(resource, :as => resource_name, :url => user_registration_path) do |f|
 
     -# For new registrations, we need to set the user's year before
     -# validation, but because we are using Devise


### PR DESCRIPTION
A registration attempt results in a routing error:

No route matches [POST] "/2014/registrations/user"

Replacing `registration_path(resource_name)` with `user_registration_path` allows a user to create an account.
