### PR TITLE
Add rb-readline gem to development requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'web-console', '~> 3.0'
+  gem 'rb-readline'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rb-readline (0.5.5)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -313,6 +314,7 @@ DEPENDENCIES
   rails (= 4.2.9)
   rails_12factor
   rb-fsevent
+  rb-readline
   responders (~> 2.0)
   rspec-rails
   rubocop


### PR DESCRIPTION
When I tried to run `bin/rails console` locally for the first time, I
received an error about readline. Based on this comment
(https://github.com/rails/rails/issues/26658#issuecomment-307238834)
I added rb-readline to the gem file, ran bundle install again, and it
worked fine.