### PR TITLE
Rewrite `button_to_get` helper

### DIFF
--- a/app/assets/stylesheets/2018/main.css.scss
+++ b/app/assets/stylesheets/2018/main.css.scss
@@ -492,8 +492,18 @@ table {
 	&.lightweight {
 		background: hsl(50, 100%, 50%);
 
+		thead {
+			th {
+				font: {
+					size: 18px;
+				}
+				text-align: left;
+			}
+		}
+
 		th {
 			text-align: right;
+			padding: 0.25em 0.5em;
 		}
 		td {
 			padding: 0.25em 0.5em;

--- a/app/assets/stylesheets/2018/main.css.scss
+++ b/app/assets/stylesheets/2018/main.css.scss
@@ -503,10 +503,10 @@ table {
 
 		th {
 			text-align: right;
-			padding: 0.25em 0.5em;
+			padding: 5px 10px;
 		}
 		td {
-			padding: 0.25em 0.5em;
+			padding: 5px 10px;
 		}
 
 		padding: 1em;

--- a/app/assets/stylesheets/2018/main.css.scss
+++ b/app/assets/stylesheets/2018/main.css.scss
@@ -592,3 +592,11 @@ ul.radio {
 hr {
 	border: 1px solid #333;
 }
+
+/* A horizontal line of stuff, each one floated left with
+some padding between each -Jared 2012-05-30 */
+.floating-padded-line-item { float: left; padding: 1em 2em 1em 0em; }
+
+.buffer-bottom {
+	margin-bottom: 1em;
+}

--- a/app/views/shared/_button_to_get.haml
+++ b/app/views/shared/_button_to_get.haml
@@ -1,9 +1,1 @@
-%button{:id => btn_id, :class => btn_class}= btn_txt
-
-:javascript
-  $(function(){
-    var btn_id = "#{btn_id}";
-    $('#' + btn_id).click(function(){
-      window.location.href = "#{btn_url}"
-    });
-  });
+%a{:id => btn_id, :class => ['button', :btn_class], :href => btn_url}= btn_txt

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -27,7 +27,7 @@
   %p No attendees yet.
 - else
   %p If you need to edit the registration form of an attendee, please select the name.
-  %table.lightweight.lightly-spaced-rows
+  %table.lightweight.lightly-spaced-rows.buffer-bottom
     %thead
       %tr
         %th Name


### PR DESCRIPTION
We've had a couple reports of the "Add Adult Attendee" button not doing
anything. It's using kind of an unnecessarily complicated means
involving JS to act as a button that links to a URL with a query
string--just using CSS to make an anchor tag look like a button is
simpler, and should eliminate any possible issue with the button.

I've also fixed the issue with the attendee box bumping directly into
the buttons beneath it.