### PR TITLE
Fix capitalization for juniors (and seniors)

### DIFF
--- a/app/assets/stylesheets/2018/main.css.scss
+++ b/app/assets/stylesheets/2018/main.css.scss
@@ -610,3 +610,7 @@ some padding between each -Jared 2012-05-30 */
 .buffer-bottom {
 	margin-bottom: 1em;
 }
+
+.clear {
+	clear: both;
+}

--- a/lib/name_inflector.rb
+++ b/lib/name_inflector.rb
@@ -4,27 +4,41 @@ module NameInflector
   # the O' in O'Brian is always capitalized.
   MANDPREF = ["o'"]
 
+  # Suffixes with mandatory capitalization
+  MANDSUF = ["jr.", "sr."]
+
   # Prefixes with optional succeeding capitals, eg.
   # Macintyre and MacIntyre are both valid
   OPTPREF = ["mac", "mc"]
 
   def self.capitalize(name)
     mandpref_match = longest_matching_prefix MANDPREF, name
+    mandsuf_match = longest_matching_suffix MANDSUF, name
     optpref_match = longest_matching_prefix OPTPREF, name
 
-    if mandpref_match.present?
-      postprefix = remove_prefix name, mandpref_match
-      mandpref_match.capitalize + postprefix.capitalize
+    if mandpref_match.present? || mandsuf_match.present? || optpref_match.present?
 
-    elsif optpref_match.present?
-      postprefix = remove_prefix name, optpref_match
-      is_first_char_uppercase?(postprefix) ? name : name.capitalize
+      if mandpref_match.present?
+        postprefix = remove_prefix name, mandpref_match
+        return mandpref_match.capitalize + postprefix.capitalize
+      end
+
+      if mandsuf_match.present?
+        presuffix = remove_suffix name, mandsuf_match
+        puts presuffix.capitalize + mandsuf_match.capitalize
+        return presuffix.capitalize + mandsuf_match.capitalize
+      end
+
+      if optpref_match.present?
+        postprefix = remove_prefix name, optpref_match
+        return optpref_match.capitalize + postprefix
+      end
 
     elsif name.include? '-'
-      name.split('-').map{|n| n.capitalize}.join('-')
+      return name.split('-').map{|n| n.capitalize}.join('-')
 
     else
-      name.capitalize
+      return name.capitalize
     end
   end
 
@@ -44,5 +58,17 @@ module NameInflector
 
   def self.remove_prefix(string, prefix)
     string.slice(prefix.length, string.length - prefix.length)
+  end
+
+  def self.longest_matching_suffix(suffixes, string)
+    matches = suffixes.select{|s| string.downcase.end_with?(s)}
+    return nil if matches.empty?
+    longest = ""
+    matches.each {|m| longest = m if m.length > longest.length }
+    return longest
+  end
+
+  def self.remove_suffix(string, suffix)
+    string.slice(0, string.length - suffix.length)
   end
 end

--- a/spec/models/name_inflector_spec.rb
+++ b/spec/models/name_inflector_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe NameInflector, :type => :model do
       expect(subject.capitalize("o'brian")).to eq("O'Brian")
     end
 
+    it "capitalizes important suffixes" do
+      expect(subject.capitalize("eagle, jr.")).to eq("Eagle, Jr.")
+      expect(subject.capitalize("EAGLE, JR.")).to eq("Eagle, Jr.")
+      expect(subject.capitalize("eagle, sr.")).to eq("Eagle, Sr.")
+      expect(subject.capitalize("eagle, Sr.")).to eq("Eagle, Sr.")
+    end
+
     # In the future, we could implement proper capitalization of
     # other, less common international names.
     #


### PR DESCRIPTION
The site's NameInflector was transforming "Nate Eagle, Jr." into "Nate
Eagle, jr.", which led to a user complaint. I added an array to deal
with suffixes that should be capitalized and added "jr." and "sr."...
perhaps someday we can add "esq."