### PR TITLE
Change select box to radio button for single plan categories

### DIFF
--- a/app/forms/registration.rb
+++ b/app/forms/registration.rb
@@ -109,6 +109,19 @@ class Registration
       .yr(year).order('plan_categories.ordinal, plans.cat_order')
   end
 
+  def convert_radio_btn_params params
+    normalized_params = {}
+    params.each do |key, value|  
+      if key.include?("single")
+        plan_id_key = params[key]["plan_id"]
+        normalized_params[plan_id_key] = { "qty"=>"1" }
+      else
+        normalized_params[key] = value
+      end
+    end
+    normalized_params
+  end
+
   # `form_plans` returns the plans to show on the form, and thus
   # excludes disabled plans unless already selected by the attendee or if
   # show_disabled is set to true.
@@ -126,7 +139,8 @@ class Registration
   end
 
   def parse_plan_params plan_params
-    Registration::PlanSelection.parse_params(plan_params, all_plans)
+    converted_params = convert_radio_btn_params(plan_params)
+    Registration::PlanSelection.parse_params(converted_params, all_plans)
   end
 
   def persist_plans

--- a/app/helpers/attendee_helper.rb
+++ b/app/helpers/attendee_helper.rb
@@ -5,7 +5,7 @@ module AttendeeHelper
     if plan.daily?
       plan_date_fields(plan, selection)
     elsif plan.max_quantity == 1
-      plan_cbx(plan, selection)
+      plan.plan_category.single === true ? plan_radio_btn(plan, selection) : plan_cbx(plan, selection)
     else
       plan_qty_field(plan, selection)
     end
@@ -23,6 +23,16 @@ module AttendeeHelper
       check_box_tag qty_field_name(plan), 1, checked, :disabled => true
     else
       check_box_tag qty_field_name(plan), 1, checked, :title => title
+    end
+  end
+
+  def plan_radio_btn(plan, selection)
+    checked = selection.qty === 1
+    title = "Select this " + mnh
+    if plan.disabled? && !current_user_is_admin?
+      radio_button_tag radio_btn_name(plan), plan.id, checked, :disabled => true
+    else
+      radio_button_tag radio_btn_name(plan), plan.id, checked, :title => title
     end
   end
 
@@ -50,6 +60,10 @@ module AttendeeHelper
 
   def qty_field_name plan
     "plans[#{plan.id}][qty]"
+  end
+
+  def radio_btn_name plan
+    "plans[single_plan_cat_id:#{plan.plan_category.id}][plan_id]" 
   end
 
 end

--- a/spec/forms/registration_spec.rb
+++ b/spec/forms/registration_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Registration do
         it 'returns an error if only selection has qty of zero' do
           plan = create :plan, :plan_category => cat
           r = Registration.new user, attendee
-          params = {plans: {plan.id => {"qty" => 0}}}
+          params = {plans: {plan.id.to_s => {"qty" => 0}}}
           expect(r.submit(ActionController::Parameters.new(params))).to eq(false)
           expect(r.errors.full_messages).to include(msg)
         end


### PR DESCRIPTION
When using radio buttons the name attribute must be the same for all
plans in the plan category. This causes the params for the plans with
radio buttons to differ from those with check boxes. I added a method to
covert the plan params using radio buttons to use the expected checkbox
format.

close #105