### PR TITLE
Add a refund_policy field to years model

### DIFF
--- a/app/assets/stylesheets/2018/_variables.scss
+++ b/app/assets/stylesheets/2018/_variables.scss
@@ -5,5 +5,6 @@ $breakpoint-stops: (
 	xs: (577px, 767px),
 	sm: (768px, 991px),
 	md: (992px, 1199px),
-	lg: (1200px, null)
+	lg: (1200px, 1599px),
+	xl: (1600px, null)
 );

--- a/app/assets/stylesheets/2018/main.css.scss
+++ b/app/assets/stylesheets/2018/main.css.scss
@@ -364,7 +364,6 @@ fieldset {
   padding: 0;
 }
 
-/*
 .field {
   display: flex;
   padding: 10px;
@@ -424,7 +423,6 @@ fieldset {
     }
   }
 }
-*/
 
 .pull-right {
   float: right;

--- a/app/assets/stylesheets/2018/main.css.scss
+++ b/app/assets/stylesheets/2018/main.css.scss
@@ -887,3 +887,42 @@ $breakpoints: map-keys($breakpoint-stops);
     }
   }
 }
+
+.align-center {
+  text-align: right;
+}
+
+.align-right {
+  text-align: right !important;
+}
+
+table.mini-calendar {
+  border-collapse: collapse;
+
+  td {
+    transition: all 0.2s;
+    &.input {
+      cursor: pointer;
+      text-align: center;
+
+      &:hover {
+        background: hsla(100, 50%, 70%, 0.5);
+      }
+    }
+    &.checked {
+      background: hsl(100, 50%, 70%) !important;
+    }
+    font: {
+      size: 14px;
+    }
+    padding: 0;
+  }
+
+  button {
+    font: {
+      size: 14px;
+    }
+    margin-top: 5px;
+    padding: 3px;
+  }
+}

--- a/app/assets/stylesheets/2018/main.css.scss
+++ b/app/assets/stylesheets/2018/main.css.scss
@@ -1,5 +1,6 @@
 @import "variables";
 @import "../functions/str-split";
+@import "../functions/decimal-round";
 @import "../mixins/breakpoint";
 @import "colonial-bullets";
 
@@ -360,8 +361,10 @@ button,
 fieldset {
   border: 5px double #333;
   margin: 1em 0;
+  padding: 0;
 }
 
+/*
 .field {
   display: flex;
   padding: 10px;
@@ -416,11 +419,12 @@ fieldset {
 
   .field_with_errors {
     display: flex;
-    >  {
+    > {
       flex: 1 1 auto;
     }
   }
 }
+*/
 
 .pull-right {
   float: right;
@@ -726,7 +730,7 @@ some padding between each -Jared 2012-05-30 */
   .side-by-side {
     display: flex;
 
-    >  {
+    > {
       flex: 1 1 auto;
     }
   }
@@ -753,21 +757,135 @@ some padding between each -Jared 2012-05-30 */
 }
 
 .list-separator {
-	margin: 0 0 0.5em;
+  margin: 0 0 0.5em;
 
-	span {
-		font-size: 18px;
-		display: inline-block;
-		margin-right: 0.5em;
-	}
+  span {
+    font-size: 18px;
+    display: inline-block;
+    margin-right: 0.5em;
+  }
 
-	.glue {
-		font-size: 18px;
-		width: 1em;
-		text-align: center;
-	}
+  .glue {
+    font-size: 18px;
+    width: 1em;
+    text-align: center;
+  }
 }
 
 [data-email-list] {
-	width: 100%;
+  width: 100%;
+}
+
+/* GOStrap */
+.d-flex {
+  display: flex;
+}
+
+.text-left {
+  text-align: left;
+}
+.text-right {
+  text-align: right;
+}
+
+/* The beginnings of a grid system */
+// Variables
+$columns-total: 12;
+
+.padded-grid {
+  [class^="col-"] {
+    padding: 10px;
+  }
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.col {
+  flex-grow: 1;
+}
+
+[class^="col-"] {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/*
+ * .col-${size}-${column}
+ */
+$breakpoints: map-keys($breakpoint-stops);
+@for $i from 2 through length($breakpoints) {
+  $breakpoint: nth($breakpoints, $i);
+  $previous-breakpoint: nth($breakpoints, $i - 1);
+  @include breakpoint("gt-#{$previous-breakpoint}") {
+    @for $i from 1 through $columns-total {
+      .col-#{$breakpoint}-#{$i} {
+        width: percentage(decimal-round($i / $columns-total, 2));
+      }
+    }
+  }
+}
+
+/*
+ * .text-${size}-${left|right}
+ */
+$breakpoints: map-keys($breakpoint-stops);
+@for $i from 1 through length($breakpoints) {
+  $breakpoint: nth($breakpoints, $i);
+  @include breakpoint("#{$breakpoint}") {
+    @for $i from 1 through $columns-total {
+      .text-#{$breakpoint}-left {
+        text-align: left;
+      }
+
+      .text-#{$breakpoint}-right {
+        text-align: right;
+      }
+    }
+  }
+}
+
+.player-list {
+  border-collapse: collapse;
+  width: 100%;
+
+  th,
+  td {
+    padding: 10px;
+  }
+
+  $thead-background: hsl(50, 70%, 50%);
+  $tbody-background: lighten($thead-background, 20%);
+
+  thead {
+    background: {
+      color: $thead-background;
+    }
+
+    th {
+      color: darken($thead-background, 20%);
+      text-align: left;
+    }
+  }
+
+  tbody {
+    font: {
+      size: 18px;
+    }
+
+    tr {
+      &:nth-child(odd) {
+        background: {
+          color: $tbody-background;
+        }
+      }
+      &:nth-child(even) {
+        background: {
+          color: lighten($tbody-background, 10%);
+        }
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/functions/_decimal-round.scss
+++ b/app/assets/stylesheets/functions/_decimal-round.scss
@@ -1,0 +1,46 @@
+// _decimal.scss | MIT License | gist.github.com/terkel/4373420
+
+// Round a number to specified digits.
+//
+// @param  {Number} $number A number to round
+// @param  {Number} [$digits:0] Digits to output
+// @param  {String} [$mode:round] (round|ceil|floor) How to round a number
+// @return {Number} A rounded number
+// @example
+//     decimal-round(0.333)    => 0
+//     decimal-round(0.333, 1) => 0.3
+//     decimal-round(0.333, 2) => 0.33
+//     decimal-round(0.666)    => 1
+//     decimal-round(0.666, 1) => 0.7
+//     decimal-round(0.666, 2) => 0.67
+@function decimal-round($number, $digits: 0, $mode: round) {
+  $n: 1;
+  // $number must be a number
+  @if type-of($number) != number {
+    @warn "#{ $number } is not a number.";
+    @return $number;
+  }
+  // $digits must be a unitless number
+  @if type-of($digits) != number {
+    @warn "#{ $digits } is not a number.";
+    @return $number;
+  } @else if not unitless($digits) {
+    @warn "#{ $digits } has a unit.";
+    @return $number;
+  }
+  @if $digits > 0 {
+    @for $i from 1 through $digits {
+      $n: $n * 10;
+    }
+  }
+  @if $mode == round {
+    @return round($number * $n) / $n;
+  } @else if $mode == ceil {
+    @return ceil($number * $n) / $n;
+  } @else if $mode == floor {
+    @return floor($number * $n) / $n;
+  } @else {
+    @warn "#{ $mode } is undefined keyword.";
+    @return $number;
+  }
+}

--- a/app/assets/stylesheets/mixins/_breakpoint.scss
+++ b/app/assets/stylesheets/mixins/_breakpoint.scss
@@ -2,48 +2,58 @@
 // Pass in any number of comma separated stops, including
 // gt- or lt- prefixes for any size.
 @mixin breakpoint($sizes...) {
-	// A map of breakpoint stops should be set in _variables.scss
-	$stops: $breakpoint-stops;
+  // A map of breakpoint stops should be set in _variables.scss
+  $stops: $breakpoint-stops;
 
-	// Iterate through the list of incoming sizes
-	@for $i from 1 through length($sizes) {
-		$size: nth($sizes, $i);
+  // Iterate through the list of incoming sizes
+  @for $i from 1 through length($sizes) {
+    $size: nth($sizes, $i);
 
-		// Check for `gt-(size)` and `lt-(size)`
-		$size: str-split($size, '-');
-		$comparison: '';
-		@if length($size) > 1 {
-			$comparison: nth($size, 1);
-			$size: nth($size, 2);
-		} @else {
-			$size: nth($size, 1);
-		}
+    // Check for `gt-(size)` and `lt-(size)`
+    $size: str-split($size, "-");
+    $comparison: "";
+    @if length($size) > 1 {
+      $comparison: nth($size, 1);
+      $size: nth($size, 2);
+    } @else {
+      $size: nth($size, 1);
+    }
 
-		@each $stop, $value in $stops {
-			@if $size == $stop {
-				@if $comparison != '' {
-					// Ex: `gt-sm` -> applies to anything greater than small
-					@if $comparison == 'gt' {
-						@media (min-width: nth($value, 2)) { @content; }
-					}
+    @each $stop, $value in $stops {
+      @if $size == $stop {
+        @if $comparison != "" {
+          // Ex: `gt-sm` -> applies to anything greater than small
+          @if $comparison == "gt" {
+            @media (min-width: nth($value, 2)) {
+              @content;
+            }
+          }
 
-					// Ex: `lt-md` -> applies to anything less than medium
-					@if $comparison == 'lt' {
-						@media (max-width: nth($value, 1)) { @content; }
-					}
-				} @else {
-					@if nth($value, 1) and nth($value, 2) {
-						// Apply minimum and maximum values
-						@media (min-width: nth($value, 1)) and (max-width: nth($value, 2)) { @content; }
-					} @else if not nth($value, 1) {
-						// Just apply a maximum
-						@media (max-width: nth($value, 2)) { @content; }
-					} @else if not nth($value, 2) {
-						// Just apply a minimum
-						@media (min-width: nth($value, 1)) { @content; }
-					}
-				}
-			}
-		}
-	}
+          // Ex: `lt-md` -> applies to anything less than medium
+          @if $comparison == "lt" {
+            @media (max-width: nth($value, 1)) {
+              @content;
+            }
+          }
+        } @else {
+          @if nth($value, 1) and nth($value, 2) {
+            // Apply minimum and maximum values
+            @media (min-width: nth($value, 1)) and (max-width: nth($value, 2)) {
+              @content;
+            }
+          } @else if not nth($value, 1) {
+            // Just apply a maximum
+            @media (max-width: nth($value, 2)) {
+              @content;
+            }
+          } @else if not nth($value, 2) {
+            // Just apply a minimum
+            @media (min-width: nth($value, 1)) {
+              @content;
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/app/controllers/rpt/usopen_players_reports_controller.rb
+++ b/app/controllers/rpt/usopen_players_reports_controller.rb
@@ -1,0 +1,67 @@
+require 'open-uri'
+
+class Rpt::UsopenPlayersReportsController < Rpt::AbstractReportController
+helper_method :self_promoter
+
+def show
+  @players = Attendee.yr(@year)
+    .where(:cancelled => false)
+    .where(:will_play_in_us_open => true).order('rank DESC')
+
+  @aga_member_info = aga_member_info
+
+  respond_to do |format|
+    format.html do
+      @players_count = @players.count
+      render :show
+    end
+    format.xml do
+      xml = PlayersXmlExporter.render(@players, @aga_member_info)
+      send_data xml, filename: xml_filename, type: 'text/xml'
+    end
+  end
+end
+
+def self_promoter(player, rating)
+  rating = rating.to_f
+  rating = player.rank < 1 ? rating.ceil() : rating.floor()
+
+  return player.rank > rating
+end
+
+private
+
+def xml_filename
+  "usopen_players_#{Time.current.strftime("%Y-%m-%d")}.xml"
+end
+
+def planlessness
+  p = params[:planlessness]
+  %w[all planful planless].include?(p) ? p.to_sym : :all
+end
+
+def aga_member_info_tsv
+  Rails.cache.fetch("usgo.org/mm/agagdtdlista.txt", :expires_in => 24.hours) do
+    open("https://www.usgo.org/mm/tdlista.txt", "r:UTF-8", &:read)
+  end
+end
+
+def aga_member_info
+  parsed_aga_member_info = {}
+  aga_member_info_tsv.each_line do |line|
+    values = line.split("\t")
+    parsed_aga_member_info[values[1]] = {
+      full_name: values[0],
+      membership_status: values[2],
+      rating: values[3],
+      expires: values[4],
+      club: values[5],
+      state: values[6],
+      sigma: values[7],
+      last_rated_on: values[8]
+    }
+  end
+  return parsed_aga_member_info
+end
+
+end

--- a/app/controllers/years_controller.rb
+++ b/app/controllers/years_controller.rb
@@ -25,8 +25,8 @@ class YearsController < ApplicationController
 
   def year_record_params
     params.require(:year_record).permit(:city, :date_range, :day_off_date,
-      :ordinal_number, :registration_phase, :reply_to_email, :start_date,
-      :state, :timezone, :twitter_url, :venue_name, :venue_address,
+      :ordinal_number, :refund_policy, :registration_phase, :reply_to_email,
+      :start_date, :state, :timezone, :twitter_url, :venue_name, :venue_address,
       :venue_city, :venue_state, :venue_zip, :venue_url, :venue_phone)
   end
 end

--- a/app/exporters/players_xml_exporter.rb
+++ b/app/exporters/players_xml_exporter.rb
@@ -1,0 +1,55 @@
+# Export Players XML for OpenGotha import
+class PlayersXmlExporter
+
+	def self.open_gotha_rank(rank_name)
+		open_gotha_rank = rank_name.gsub(/ kyu/, 'K').gsub(/ dan/, 'D')
+	end
+
+	def self.open_gotha_rating(rank)
+		# Adjust dan ranks down one to make up for the fact that we skip a number
+		# between -1 and 1
+		if rank > 0
+			rank -= 1
+		end
+
+		base_rating = -900
+		open_gotha_rating = base_rating + ((30 + rank) * 100)
+	end
+
+  def self.render_player(player, aga_info)
+		xmlTag = {
+			agaExpirationDate: aga_info[:expires],
+			agaId: player.aga_id,
+			firstName: player.given_name,
+			name: player.family_name,
+			grade: open_gotha_rank(player.rank_name),
+			rank: open_gotha_rank(player.rank_name),
+			rating: open_gotha_rating(player.rank),
+			club: aga_info[:club]
+		}
+
+
+		str = ""
+		xmlTag.each do |attribute, value|
+			str += "#{attribute}=\"#{value}\" "
+		end
+		str = "<Player " + str + "/>"
+  end
+
+	def self.render_players(players, aga_info)
+		players = players.map {|player| render_player(player, aga_info[player.aga_id.to_s] || {})}
+		players.join("\n\t\t")
+	end
+
+  def self.render players, aga_info
+		<<~EOF
+		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+		<Tournament dataVersion="201">
+			<Players>
+				#{render_players(players, aga_info)}
+			</Players>
+		</Tournament>
+		EOF
+  end
+
+end

--- a/app/helpers/attendee_helper.rb
+++ b/app/helpers/attendee_helper.rb
@@ -47,6 +47,14 @@ module AttendeeHelper
     )
   end
 
+  def plan_label_name plan
+    if plan.max_quantity == 1
+      plan.plan_category.single === true ?
+        "plans_single_plan_cat_id:#{plan.plan_category.id}_plan_id_#{plan.id}" :
+        qty_field_name(plan)
+    end
+  end
+
   private
 
   def mnh

--- a/app/models/attendee/who_is_coming.rb
+++ b/app/models/attendee/who_is_coming.rb
@@ -68,7 +68,7 @@ class Attendee::WhoIsComing
   def find_attendees
     qry_params = {
       year: @year.to_i,
-      congress_start_date: CONGRESS_START_DATE[@year]
+      congress_start_date: CONGRESS_START_DATE[@year.to_i]
     }
     Attendee.find_by_sql [attendees_qry(order_clause), qry_params]
   end

--- a/app/models/attendee/who_is_coming.rb
+++ b/app/models/attendee/who_is_coming.rb
@@ -66,7 +66,10 @@ class Attendee::WhoIsComing
   end
 
   def find_attendees
-    qry_params = {year: @year.to_i}
+    qry_params = {
+      year: @year.to_i,
+      congress_start_date: CONGRESS_START_DATE[@year]
+    }
     Attendee.find_by_sql [attendees_qry(order_clause), qry_params]
   end
 

--- a/app/models/attendee/who_is_coming.rb
+++ b/app/models/attendee/who_is_coming.rb
@@ -40,7 +40,7 @@ class Attendee::WhoIsComing
   end
 
   def unregistered_count
-    Attendee.yr(@year).count - @attendees.count
+    Attendee.yr(@year).count - @attendees.count - Attendee.yr(@year).attendee_cancelled.count
   end
 
   private

--- a/app/models/attendee/who_is_coming.sql
+++ b/app/models/attendee/who_is_coming.sql
@@ -33,16 +33,8 @@ where attendees.year = :year and attendees.cancelled = false
   -- credits minus debits must be at least $70
   and coalesce(credits.total, 0) - coalesce(debits.total, 0) >= 7000
 
-  -- exclude attendees with child registration plan
-  and not exists (
-    select ap.attendee_id
-    from attendee_plans ap
-    inner join plans p on p.id = ap.plan_id
-    where attendees.id = ap.attendee_id
-      and ap.year = :year
-      and p.year = :year
-      and p.name like 'Child Registration'
-  )
+  -- exclude attendees under thirteen
+  and attendees.birth_date < (:congress_start_date::date - interval '13 years')
 
   -- exclude cancelled attendees
   and not exists (

--- a/app/views/plan_categories/_plan_table_common_cells.html.haml
+++ b/app/views/plan_categories/_plan_table_common_cells.html.haml
@@ -1,5 +1,10 @@
-%td= plan.age_range_in_words
-%td= markdown(plan.description).html_safe
+%td
+  %label{for: plan_label_name(plan)}= plan.age_range_in_words
+%td
+  %label{for: plan_label_name(plan)}
+    = markdown(plan.description).html_safe
 - if @show_availability
-  %td= plan.describe_inventory_available
-%td.numeric= plan.price_for_display
+  %td
+    %label{for: plan_label_name(plan)}= plan.describe_inventory_available
+%td.numeric
+  %label{for: plan_label_name(plan)}= plan.price_for_display

--- a/app/views/plan_categories/_plan_table_plan_row.html.haml
+++ b/app/views/plan_categories/_plan_table_plan_row.html.haml
@@ -1,4 +1,5 @@
 %tr{:class => if plan.disabled? then "disabled" end}
-  %td.valign-middle.align-center= plan_selection_inputs(plan)
-  %td= plan.name
+  %td.valign-middle.align-right= plan_selection_inputs(plan)
+  %td
+    %label{for: plan_label_name(plan)}= plan.name
   = render :partial => "plan_categories/plan_table_common_cells", :locals => { :plan => plan }

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -25,6 +25,10 @@
   %li= link_to "Outstanding Balances", rpt_outstanding_balance_report_path
   %li= link_to "Transactions", rpt_transaction_report_path
 
+%h3 Tournaments
+%ul
+  %li= link_to "U.S. Open Players Report", rpt_usopen_players_report_path
+
 %h3 Activities
 %ul
   %li= link_to Activity.model_name.human.pluralize, activities_reports_path

--- a/app/views/rpt/usopen_players_reports/show.html.haml
+++ b/app/views/rpt/usopen_players_reports/show.html.haml
@@ -1,0 +1,43 @@
+-#%h2= page_title
+%h2 U.S. Open Players Report
+
+- amnh = Attendee.model_name.human
+- xml_path = rpt_usopen_players_report_path + '.xml'
+
+= form_tag(xml_path, :method => :get) do
+  %p.pull-right= submit_tag "Export"
+
+%p
+  There are
+  = pluralize(@players.count, amnh.downcase)
+  registered to play in the U.S. Open.
+
+%table.player-list
+  %thead
+    %tr
+      %th Player Name
+      %th Rank
+      %th AGA Rating
+      %th Last Rated
+      %th Flag
+  %tbody
+  - @players.each do |player|
+    - aga_info = @aga_member_info[player.aga_id.to_s]
+    %tr
+      %td
+        = NameInflector.capitalize(player.given_name)
+        = NameInflector.capitalize(player.family_name)
+        - if player.aga_id
+          (#{link_to "#{player.aga_id}", "http://agagd.usgo.org/player/#{player.aga_id}"})
+      %td= player.rank_name
+      %td= aga_info ? aga_info[:rating] : '-'
+      %td= aga_info ? aga_info[:last_rated_on] : '-'
+      %td
+        - if aga_info
+          - if self_promoter(player, aga_info[:rating])
+            Self-promoted
+
+%h3 Export to XML
+%p Import into OpenGotha by selecting <strong>Tournament &rarr; Import &hellip; &rarr; Import Tournament From XML File</strong>.
+= form_tag(xml_path, :method => :get) do
+  %p= submit_tag "Export"

--- a/app/views/shared/_plan_date_fields.haml
+++ b/app/views/shared/_plan_date_fields.haml
@@ -4,31 +4,49 @@
     - @plan_calendar.each do |week|
       %tr
         - week.each do |d|
-          %td.nowrap
+          %td.nowrap{:class => ("input" if d.present?)}
             - if d.present?
               - format = first_clndr_date ? '%-m/%-e' : '%-e'
               = d.strftime(format)
-              %br
               - checked = selection.dates.include?(d)
               - @cbx_name = "plans[#{plan.id}][dates][]"
               = check_box_tag @cbx_name, d.strftime('%Y-%m-%d'), checked
               - first_clndr_date = false
     %tr
-      %td{:colspan=>3}
+      %td{:colspan=>10, :class => 'align-right'}
         = button_tag('Set All', type: 'button', name: 'setAll_' + @cbx_name)
-      %td
-      %td{:colspan=>3}
         = button_tag('Clear', type: 'button', name: 'clear_' + @cbx_name)
 
 :javascript
   $("[name='setAll_#{@cbx_name}']").click(function() {
-    $("[name='#{@cbx_name}']").each(function() {
-      this.checked = true;
+    $("[name='#{@cbx_name}']").each(function(i, checkbox) {
+      if (!this.checked) {
+        $(this).trigger('click');
+      }
     });
   });
 
+  $("[name='#{@cbx_name}']").on('change', function(event) {
+    var $target = $(event.currentTarget);
+    var $td = $target.closest('td');
+    if ($target.prop('checked')) {
+      $td.addClass('checked');
+    } else {
+      $td.removeClass('checked');
+    }
+  });
+
+  $("[name='#{@cbx_name}']").closest('td').click(function(event) {
+    if (!$(event.target).is('input')) {
+      var checkbox = $(this).find('input');
+      checkbox.trigger('click');
+    }
+  });
+
   $("[name='clear_#{@cbx_name}']").click(function() {
-    $("[name='#{@cbx_name}']").each(function() {
-      this.checked = false;
+    $("[name='#{@cbx_name}']").each(function(event) {
+      if (this.checked) {
+        $(this).trigger('click');
+      }
     });
   });

--- a/app/views/users/pay.html.haml
+++ b/app/views/users/pay.html.haml
@@ -26,12 +26,9 @@
           %br
           %input{ :type => "submit", :name => "submit", :value => "Continue" }
 
-- if @year.year == 2012
+- if @year.refund_policy
   %h3 Refund Policy
-  %p
-    Full refunds minus a $50 processing fee and any credit card fees will be
-    provided until July 1, 2012. After July 1st, a $75 processing fee and any
-    credit card fees will be deducted from the refund.
+  %p= @year.refund_policy
 
 %br
 

--- a/app/views/years/_form.html.haml
+++ b/app/views/years/_form.html.haml
@@ -54,6 +54,12 @@
       = f.label :venue_phone
       = f.text_field :venue_phone, :size => 20
 
+  %h3 Policies
+  %fieldset
+    .field
+      = f.label :refund_policy
+      = f.text_area :refund_policy
+      
   %h3 Miscellaneous
   %fieldset
     .field

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,10 @@ Gocongress::Application.routes.draw do
             resource :daily_plan_report, :only => :show
             resource :transaction_report, :only => :show
           end
+
+          constraints :format => /(xml)?/ do
+            resource :usopen_players_report, :only => :show
+          end
         end
 
         # This route provides `year_path`, so it's not defunct,

--- a/db/migrate/20180508025356_add_refund_policy_to_year.rb
+++ b/db/migrate/20180508025356_add_refund_policy_to_year.rb
@@ -1,0 +1,5 @@
+class AddRefundPolicyToYear < ActiveRecord::Migration[5.0]
+  def change
+    add_column :years, :refund_policy, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180322102515) do
+ActiveRecord::Schema.define(version: 20180508025356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -265,6 +265,7 @@ ActiveRecord::Schema.define(version: 20180322102515) do
     t.string  "venue_state",        limit: 2
     t.string  "venue_zip",          limit: 10
     t.string  "venue_phone",        limit: 20
+    t.text    "refund_policy"
     t.index ["year"], name: "index_years_on_year", unique: true, using: :btree
   end
 

--- a/spec/factories/attendees.rb
+++ b/spec/factories/attendees.rb
@@ -16,6 +16,13 @@ FactoryBot.define do
     association :user, :factory => :user, :strategy => :build
   end
 
+  factory :teenager, :parent => :attendee do
+    birth_date CONGRESS_START_DATE[Time.now.year] - 15.years
+    guardian_full_name "Mother Dearest"
+    understand_minor true
+    association :guardian, :factory => :attendee, :strategy => :build
+  end
+
   factory :minor, :parent => :attendee do
     birth_date CONGRESS_START_DATE[Time.now.year] - 10.years
     guardian_full_name "Mother Dearest"

--- a/spec/models/attendee/who_is_coming_spec.rb
+++ b/spec/models/attendee/who_is_coming_spec.rb
@@ -91,5 +91,12 @@ RSpec.describe Attendee::WhoIsComing, :type => :model do
         Attendee::WhoIsComing.new(u1.year).attendees.map(&:given_name)
       ).to match_array(['u1a', 'u2a', 'u3a', 'u3b', 'u4a', 'u4b', 'u6a'])
     end
+
+    it 'excludes cancelled attendees from unregistered count' do
+      a = create :attendee
+      cancelled_attendee = create :attendee, cancelled: true
+
+      expect(Attendee::WhoIsComing.new(a.year).unregistered_count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Our refund/cancellation policy was one of the first things a user asked
for this year when registration opened. Which makes sense! This is
something every year's Congress should be prompted to set, and should
always show on the "Make a Payment" page.

It also adds a new "policies" box of settings to the admin, which will
be a good place to add any always-relevant policy fields to help each
year's Congress kick things off.