### PR TITLE
Add `minor_agreement_received` checkbox for admin

### DIFF
--- a/app/controllers/rpt/minor_agreements_reports_controller.rb
+++ b/app/controllers/rpt/minor_agreements_reports_controller.rb
@@ -1,0 +1,18 @@
+class Rpt::MinorAgreementsReportsController < Rpt::AbstractReportController
+
+def show
+  @minors_without_agreements = Attendee.yr(@year)
+    .where(
+      "birth_date > ? and minor_agreement_received = false",
+      CONGRESS_START_DATE[@year.to_i] - 18.years
+    )
+  @minors_with_agreements = Attendee.yr(@year)
+    .where(
+      "birth_date > ? and minor_agreement_received = true",
+      CONGRESS_START_DATE[@year.to_i] - 18.years
+    )
+
+  @congress_start_date = CONGRESS_START_DATE[@year.to_i]
+end
+
+end

--- a/app/views/registrations/_form.html.haml
+++ b/app/views/registrations/_form.html.haml
@@ -17,14 +17,8 @@
   - unless @year.year == 2016
     = render :partial => 'activities', :locals => { :f => f }
 
-  -# If we show the admin fields, we'll get MassAssignmentSecurity::Error
-  -# Can't mass-assign protected attributes: minor_agreement_received, comment
-  -# We need to be able to specify the mass-assignment role to cancan,
-  -# but that feature is still in the works:
-  -# https://github.com/ryanb/cancan/pull/686
-  -#
-  -# - if current_user.admin?
-  -#   = render :partial => 'admin_info', :locals => { :f => f }
+  - if current_user.admin?
+    = render :partial => 'admin_info', :locals => { :f => f }
 
   %p= f.submit 'Continue'
 

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -12,6 +12,7 @@
   %li= link_to "Attendee Email Addresses", "reports/emails"
   %li= link_to "Attendees", rpt_attendee_report_path
   %li= link_to "Users with No Attendees", rpt_attendeeless_user_report_path
+  %li= link_to "Minor Agreements Report", rpt_minor_agreements_report_path
 
 %h3 Plans
 %ul

--- a/app/views/rpt/minor_agreements_reports/show.html.haml
+++ b/app/views/rpt/minor_agreements_reports/show.html.haml
@@ -1,0 +1,61 @@
+%h2= page_title
+
+- amnh = Attendee.model_name.human
+
+%p
+  All attendees who will not turn eighteen by
+  %span=@congress_start_date.strftime("%B %-d, %Y")
+  are considered minors, and must submit a Youth Attendance Agreement.
+
+%p
+  The checkbox to mark an attendee&rsquo;s agreement as received is at the
+  bottom of their registration form, visible only to admins.
+
+%h3 Attendees without Minor Agreements (#{@minors_without_agreements.count})
+
+%table.semantic.zebra.fullwidth
+  %thead
+    %tr
+      %th Name
+      %th Birth Date
+      %th Email
+      %th Guardian
+      %th
+  %tbody
+
+  - @minors_without_agreements.each do |minor|
+    %tr
+      %td
+        = link_to minor.full_name, edit_registration_path(minor, type: 'youth')
+      %td
+        #{minor.birth_date.strftime("%B %-d, %Y")}
+      %td
+        = minor.email
+      %td
+        = minor.guardian_full_name
+      %td
+        = link_to "Account", user_path(minor.user_id)
+
+%h3 Attendees with Minor Agreements (#{@minors_with_agreements.count})
+
+%table.semantic.zebra.fullwidth
+  %thead
+    %tr
+      %th Name
+      %th Birth Date
+      %th Email
+      %th Guardian
+      %th
+  %tbody
+  - @minors_with_agreements.each do |minor|
+    %tr
+      %td
+        = link_to minor.full_name, edit_registration_path(minor, type: 'youth')
+      %td
+        #{minor.birth_date.strftime("%B %-d, %Y")}
+      %td
+        = minor.email
+      %td
+        = minor.guardian_full_name
+      %td
+        = link_to "Account", user_path(minor.user_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Gocongress::Application.routes.draw do
         namespace :rpt do
           resource :attendeeless_user_report, :only => :show
           resource :outstanding_balance_report, :only => :show
+          resource :minor_agreements_report, :only => :show
 
           # These reports support CSV format
           constraints :format => /(csv)?/ do

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -358,6 +358,14 @@ RSpec.describe RegistrationsController, :type => :controller do
         expect(a.reload.family_name).to eq('banana')
       end
 
+      it "can update admin fields" do
+        attrs = attendee_attributes.merge({:comment => 'banana'})
+        expect {
+          patch :update, params: { id: a.id, registration: attrs, year: a.year }
+        }.to change { a.reload.family_name }
+        expect(a.reload.comment).to eq('banana')
+      end
+
       it 'can select plan for attendee belonging to someone else' do
         plan = create :plan
         expect(a.plans).to be_empty

--- a/spec/controllers/rpt/minor_agreements_reports_controller_spec.rb
+++ b/spec/controllers/rpt/minor_agreements_reports_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+require "controllers/rpt/shared_examples_for_reports"
+
+RSpec.describe Rpt::MinorAgreementsReportsController, :type => :controller do
+  it_behaves_like "a report", %w[html]
+
+  describe "#show" do
+    it "shows minors in the correct group" do
+      sign_in create :admin
+
+      # One minor has had not their agreement received
+      a1 = create :attendee,
+        :birth_date => "2006-09-10",
+        :guardian_full_name => "Uncle Jimmy"
+
+      # But one minor has!
+      a2 = create :attendee,
+        :birth_date => "2008-03-12",
+        :guardian_full_name => "Aunt Jane",
+        :minor_agreement_received => true
+
+      get :show, params: { year: Time.now.year }
+      expect(assigns(:minors_without_agreements).map(&:id)).to match_array([a1.id])
+      expect(assigns(:minors_with_agreements).map(&:id)).to match_array([a2.id])
+    end
+  end
+end


### PR DESCRIPTION
Closes #79.

I started to create a migration to add this checkbox, which has been
requested by our registrar and a previous registrar, only to discover
that it already existed. It looks like there used to be an issue with
the way the project originally protected admin-only attributes in the
registration form.

This restores these fields, then adds some new logic to the registration
controller to ensure that only admins can update these fields. @rcristal,
definitely let me know if you have any questions about how that new
logic works.

This also adds a (very simple) report to the `rpt` namespace to show a
list of minor attendees for whom we've got an agreement and those for
whom we don't.

* Adds a test to verify that admins can update admin-only fields in reg
* Adds a test of the new report controller