### PR TITLE
Add table of contents option to content categories

### DIFF
--- a/app/controllers/content_categories_controller.rb
+++ b/app/controllers/content_categories_controller.rb
@@ -47,6 +47,6 @@ protected
   private
 
   def content_category_params
-    params.require(:content_category).permit(:name)
+    params.require(:content_category).permit(:name, :table_of_contents)
   end
 end

--- a/app/views/content_categories/_form.html.haml
+++ b/app/views/content_categories/_form.html.haml
@@ -6,5 +6,9 @@
     = f.text_field :name, tab_index: 1
 
   .field
+    = f.label :table_of_contents
+    = f.check_box :table_of_contents, tab_index: 2
+
+  .field
     %label
     = f.submit 'Save'

--- a/app/views/content_categories/show.html.haml
+++ b/app/views/content_categories/show.html.haml
@@ -6,10 +6,23 @@
   - if can? :edit, ContentCategory
     = button_to "Edit This Category", edit_content_category_path(@content_category), :method => :get
 
+- if @content_category.table_of_contents
+  %h3
+    Table of Contents
+  %ul
+    - @contents.each do |c|
+      %li
+        = link_to c.subject, content_path(c)
+
 - @contents.each do |c|
-  %h3= c.subject
-  = markdown(c.body).html_safe
-  - if can? :manage, c
-    .row-of-buttons
-      = button_to "Edit", edit_content_path(c), :method => :get
-      = button_to "Delete", c, :method => :delete, :data => {:confirm => 'Are you sure?'}
+
+  %span.anchor{id: c.subject.parameterize}
+  %div.content-item
+    %h3
+      = c.subject
+
+    = markdown(c.body).html_safe
+    - if can? :manage, c
+      .row-of-buttons
+        = button_to "Edit", edit_content_path(c), :method => :get
+        = button_to "Delete", c, :method => :delete, :data => {:confirm => 'Are you sure?'}

--- a/app/views/content_categories/show.html.haml
+++ b/app/views/content_categories/show.html.haml
@@ -14,6 +14,8 @@
       %li
         = link_to c.subject, content_path(c)
 
+  %hr
+
 - @contents.each do |c|
 
   %span.anchor{id: c.subject.parameterize}

--- a/app/views/contents/_form.html.haml
+++ b/app/views/contents/_form.html.haml
@@ -6,7 +6,7 @@
     = f.text_field :subject
   .field
     = f.label :content_category_id
-    = f.select :content_category_id, content_category_options, :selected => params[:content_category_id]
+    = f.select :content_category_id, content_category_options, :selected => @content.content_category.id
   .field
     = render partial: "shared/md_area", locals: { :obj => :content, :atr => :body, :rows => 20 }
   .field

--- a/app/views/contents/show.html.haml
+++ b/app/views/contents/show.html.haml
@@ -17,5 +17,7 @@
 
 %br
 
+  = button_to "Back to #{@content.content_category.name}", content_category_path(@content.content_category), :method => :get
+
 - if can? :manage, @content
   = button_to 'Edit', edit_content_path(@content), :method => :get

--- a/db/migrate/20180524165637_add_table_of_contents_to_content_category.rb
+++ b/db/migrate/20180524165637_add_table_of_contents_to_content_category.rb
@@ -1,0 +1,5 @@
+class AddTableOfContentsToContentCategory < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_categories, :table_of_contents, :boolean, default: false
+  end
+end


### PR DESCRIPTION
Some content categories--I'm looking at you, FAQ!--really need a nice
table of contents at the top to let people quickly scan all the items
and click particular ones that interest them.

This creates a new column attached to content_categories that turns on a
TOC and outputs it as a list of links at the top of the page in the
view.

![image](https://user-images.githubusercontent.com/176993/40508696-65b71e38-5f66-11e8-9130-65676ce25029.png)

![image](https://user-images.githubusercontent.com/176993/40509029-dcb33f3a-5f66-11e8-822c-c840527b9c1f.png)

There are no current tests for `content_categories` or `contents` -- it will probably be worth it to get some set up someday, but they're extremely simple and this is a very simple additional feature.