### PR TITLE
Provide a "no selection" option for non-mandatory, single-value plans

### DIFF
--- a/app/helpers/attendee_helper.rb
+++ b/app/helpers/attendee_helper.rb
@@ -66,12 +66,17 @@ module AttendeeHelper
       Registration::PlanSelection.new(plan, 0)
   end
 
+  # Return selected plan for a given plan category
+  def plan_category_selection category
+    @registration.plan_selections.select { |ps| ps.plan.plan_category_id == category.id }
+  end
+
   def qty_field_name plan
     "plans[#{plan.id}][qty]"
   end
 
   def radio_btn_name plan
-    "plans[single_plan_cat_id:#{plan.plan_category.id}][plan_id]" 
+    "plans[single_plan_cat_id:#{plan.plan_category.id}][plan_id]"
   end
 
 end

--- a/app/views/plan_categories/_plan_table_plan_row.html.haml
+++ b/app/views/plan_categories/_plan_table_plan_row.html.haml
@@ -1,5 +1,15 @@
-%tr{:class => if plan.disabled? then "disabled" end}
-  %td.valign-middle.align-right= plan_selection_inputs(plan)
-  %td
-    %label{for: plan_label_name(plan)}= plan.name
-  = render :partial => "plan_categories/plan_table_common_cells", :locals => { :plan => plan }
+- if defined? plan
+  %tr{:class => if plan.disabled? then "disabled" end}
+    %td.valign-middle.align-right
+      = plan_selection_inputs(plan)
+    %td
+      %label{for: plan_label_name(plan)}= plan.name
+    = render :partial => "plan_categories/plan_table_common_cells", :locals => { :plan => plan }
+- else
+  -# If no plan is provided, provide a "no selection" radio button
+  %tr
+    %td.valign-middle.align-right
+      = radio_button_tag "plans[single_plan_cat_id:#{category.id}][plan_id]", '', plan_category_selection(category).blank? ? true : false, :title => "Select None"
+    %td{:colspan => 5}
+      %label{for: "plans_single_plan_cat_id:#{category.id}_plan_id_"}
+        No Selection

--- a/app/views/registrations/_plans.haml
+++ b/app/views/registrations/_plans.haml
@@ -26,14 +26,15 @@
         = render :partial => "plan_categories/plan_table_common_headers"
     %tbody
       - @registration.plans_by_category.each do |cat, plans|
-        %tr
-          %th{:colspan => 6}= cat.name
         - if cat.show_description?
           %tr{ class: 'description' }
             %td{:colspan => 6}= markdown_if_present(cat.description)
         - if cat.extended_description?
           %tr{ class: 'extended-description' }
             %td{:colspan => 6}= markdown_if_present(cat.extended_description)
+        - if !cat.mandatory and cat.single
+          -# Provide "No Selection" option for non-mandatory, single-value plans
+          = render :partial => "plan_categories/plan_table_plan_row", :locals => { :category => cat }
         - plans.each do |plan|
           - if params[:type] == "adult" && plan.age_min >= 18
             = render :partial => "plan_categories/plan_table_plan_row", :locals => { :plan => plan }


### PR DESCRIPTION
There was a UI scenario that I overlooked in the recent change from check-boxes to radio buttons for single-value plans: when it's a non-mandatory plan, there needs to be a way for a user to select "none" if they click on a plan but change their mind.