### PR TITLE
Fix new content to choose correct default category

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -12,6 +12,14 @@ class ContentsController < ApplicationController
     @contents = @contents.yr(@year)
   end
 
+  def new
+    @selected_category_id = params[:content_category_id]
+  end
+
+  def edit
+    @selected_category_id = @content.content_category.id
+  end
+
   def create
     @content.year = @year.year
     if @content.save

--- a/app/views/contents/_form.html.haml
+++ b/app/views/contents/_form.html.haml
@@ -6,7 +6,7 @@
     = f.text_field :subject
   .field
     = f.label :content_category_id
-    = f.select :content_category_id, content_category_options, :selected => @content.content_category.id
+    = f.select :content_category_id, content_category_options, :selected => @selected_category_id
   .field
     = render partial: "shared/md_area", locals: { :obj => :content, :atr => :body, :rows => 20 }
   .field


### PR DESCRIPTION
* Use the `content_category_id` for new content
* Use the category_id from existing content for edit