### PR TITLE
Remove cancelled attendees from the pros list

### DIFF
--- a/app/controllers/attendees_controller.rb
+++ b/app/controllers/attendees_controller.rb
@@ -32,6 +32,10 @@ class AttendeesController < ApplicationController
   end
 
   def vip
-    @attendees = Attendee.yr(@year).where('rank >= 101').order('rank desc')
+    @attendees = Attendee
+      .yr(@year)
+      .where(:cancelled => false)
+      .where('rank >= 101')
+      .order('rank desc')
   end
 end

--- a/spec/controllers/attendees_controller_spec.rb
+++ b/spec/controllers/attendees_controller_spec.rb
@@ -24,6 +24,32 @@ RSpec.describe AttendeesController, :type => :controller do
         expect(response).to be_forbidden
       end
     end
+
+    describe "#vip" do
+      it "lists registered pros" do
+        a1 = create :attendee, rank: 109
+        a2 = create :attendee, rank: 108
+        # 7 dans are not pros!
+        a3 = create :attendee, rank: 7
+
+        get :vip, params: { year: Time.current.year }
+
+        expect(assigns(:attendees).count).to be(2)
+      end
+
+      it "doesn't list cancelled pros" do
+        a1 = create :attendee, rank: 109
+        # Cancelled!
+        a2 = create :attendee, rank: 108, cancelled: true
+        # 7 dans are not pros!
+        a3 = create :attendee, rank: 7
+
+        get :vip, params: { year: Time.current.year }
+
+        expect(assigns(:attendees).count).to be(1)
+      end
+  end
+
   end
 
   context "as a user" do


### PR DESCRIPTION
We had a report of a pro who'd been registered by a friend. They were
cancelled, but still showing up on the pros (vip) list.