### PR TITLE
Make registration form more readable

### DIFF
--- a/app/assets/stylesheets/2018/main.css.scss
+++ b/app/assets/stylesheets/2018/main.css.scss
@@ -487,7 +487,7 @@ table {
     th,
     td {
       margin: 0;
-      padding: 0.25em 0.5em;
+      padding: 10px 20px;
       text-align: left;
     }
 
@@ -497,26 +497,42 @@ table {
       }
     }
 
+    .description, .extended-description {
+      td {
+        background: hsla(0, 0%, 100%, 0.5);
+        padding: 10px 20px;
+        position: relative;
+      }
+
+      p {
+        margin: 0 0 0.5em;
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+
+
+    }
     .description {
       td {
         position: relative;
-        background: hsla(0, 0%, 100%, 0.5);
         color: hsl(50, 20%, 20%);
-        padding: 10px 20px !important;
         font: {
-          size: 24px;
+          size: 20px;
         }
       }
     }
 
     .extended-description {
       td {
-        position: relative;
-        background: hsla(0, 0%, 100%, 0.5);
         color: hsl(50, 20%, 20%);
-        padding: 0 20px 10px !important;
         font: {
           size: 18px;
+        }
+        padding-top: 0;
+
+        p:first-child {
+          margin-top: 0;
         }
       }
     }
@@ -1120,4 +1136,8 @@ input[type="radio"] {
   p {
     margin: 0;
   }
+}
+
+a.extended-description {
+  text-decoration: none;
 }

--- a/app/views/registrations/_plans.haml
+++ b/app/views/registrations/_plans.haml
@@ -19,19 +19,25 @@
   = link_to 'registrar.', contacts_path
 
 - if @registration.plans_by_category.count > 0
-  %table.semantic.fullwidth
-    %thead
-      %tr
-        %th
-        = render :partial => "plan_categories/plan_table_common_headers"
-    %tbody
-      - @registration.plans_by_category.each do |cat, plans|
+  - @registration.plans_by_category.each do |cat, plans|
+    %table.semantic.fullwidth.buffer-bottom
+      %thead
+        %tr{ class: 'category-name' }
+          %th{:colspan => 6}= cat.name
         - if cat.show_description?
           %tr{ class: 'description' }
             %td{:colspan => 6}= markdown_if_present(cat.description)
-        - if cat.extended_description?
-          %tr{ class: 'extended-description' }
-            %td{:colspan => 6}= markdown_if_present(cat.extended_description)
+
+          - if cat.extended_description?
+            %tr{ class: 'extended-description' }
+              %td{:colspan => 6}
+                %a{:class => 'extended-description', :href => '#'} More Details &raquo;
+                %div{:class => 'extended-description-content', :style => 'display: none;'}
+                  = markdown_if_present(cat.extended_description)
+        %tr
+          %th
+            = render :partial => "plan_categories/plan_table_common_headers"
+      %tbody
         - if !cat.mandatory and cat.single
           -# Provide "No Selection" option for non-mandatory, single-value plans
           = render :partial => "plan_categories/plan_table_plan_row", :locals => { :category => cat }
@@ -42,5 +48,16 @@
             = render :partial => "plan_categories/plan_table_plan_row", :locals => { :plan => plan }
           - if plan.age_min <= 17 && plan.age_max.blank?
             = render :partial => "plan_categories/plan_table_plan_row", :locals => { :plan => plan }
+
+:javascript
+  // Provide "More details" button for extended descriptions
+  $("a.extended-description").click(function(event) {
+    event.preventDefault();
+    var $target = $(event.target);
+    var $extendedDescription = $target.next('.extended-description-content');
+
+    $target.hide();
+    $extendedDescription.fadeIn('fast');
+  });
 
 = render :partial => "plan_categories/explain_availability"


### PR DESCRIPTION
* Add plan category names
* separate plan tables visually to provide more clarity
* Hide extended descriptions by default, allow them to be shown when a
  user clicks "more details"

![image](https://user-images.githubusercontent.com/176993/41921328-a1225c88-7930-11e8-8572-27df92b4498e.png)

@rcristal This is a front-end-only PR--as per our last discussion, I'm going to push it to heroku.