### PR TITLE
Temporarily add static information to "Who's Coming"

### DIFF
--- a/app/views/attendees/index.html.haml
+++ b/app/views/attendees/index.html.haml
@@ -1,40 +1,1573 @@
 %h2 Who is Coming?
 
-- if @year.registration_phase == "closed"
-  %p Registration for the #{@year.year} Go Congress has not yet begun.
+%p There are 306 people registered, including 52 youth who are not listed here for privacy reasons. Since this year's registration is through the University of Wisconsin, this list isn't dynamically updated, and will lag a bit behind current numbers.
 
-- else
-  - if @who_is_coming.count > 0
-    %p
-      There are #{ @who_is_coming.count } people registered, including
-      #{@who_is_coming.kyu_count} kyu players, #{@who_is_coming.dan_count} dan
-      players, and #{pluralize(@who_is_coming.pro_count, 'pro')}.
-      Also, #{@who_is_coming.unregistered_count} other people have not finished
-      their registration.  A payment of at least $70 must be made before
-      attendees of an account can appear on this list.  Attendees with a child
-      registration plan will not appear on this list.
+%p Haven't registered yet? <a href="https://uwmadison.eventsair.com/gocongress19/reg">Register now!</a>
 
-    - unless anyone_signed_in?
-      %p
-        Are you coming?  Please
-        = link_to 'register!', new_user_registration_path
 
-    %table.semantic.fullwidth.zebra
-      %thead
-        %tr
-          %th
-          - %w[given_name family_name rank country created_at].each do |c|
-            - drn = (c == params[:sort]) ? @who_is_coming.opposite_direction : :asc
-            %th= link_to trl_attr(:attendee, c), :sort => c, :direction => drn
-      %tbody
-        - @who_is_coming.attendees.each_with_index do |a,i|
-          %tr{:class => if a.anonymous then "understated" end }
-            %td= i + 1
-            %td= a.given_name_anonymized
-            %td= a.family_name_anonymized
-            %td= a.rank_name
-            %td= a.anonymize_attribute :country
-            %td= a.created_at.to_date.to_formatted_s(:rfc822)
-  - else
-    %p
-      This list is currently not available.
+%table.semantic.fullwidth.zebra
+  %thead
+    %tr
+      %th Given Name
+      %th Family Name
+      %th State (If U.S.)
+      %th Country
+      %th Rating
+  %tbody
+    %tr
+      %td Ashley
+      %td Albright
+      %td Ohio
+      %td United States
+      %td Non-Player
+    %tr
+      %td Dallas
+      %td Amunrud
+      %td Oregon
+      %td United States
+      %td 18 kyu
+    %tr
+      %td Chen
+      %td An
+      %td North Carolina
+      %td United States
+      %td 7 dan
+    %tr
+      %td Keith
+      %td Arnold
+      %td Maryland
+      %td United States
+      %td 4 dan
+    %tr
+      %td Bob
+      %td Bacon
+      %td North Carolina
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Fritz Balwit
+      %td Balwit
+      %td Oregon
+      %td United States
+      %td 1 dan
+    %tr
+      %td David
+      %td Baran
+      %td California
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Paul
+      %td Barchilon
+      %td Colorado
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Jacob
+      %td Beddingfield
+      %td California
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Terry
+      %td Benson
+      %td New York
+      %td United States
+      %td 1 kyu
+    %tr
+      %td JIM
+      %td Benthem
+      %td Michigan
+      %td United States
+      %td 1 dan
+    %tr
+      %td Colette
+      %td Bezio
+      %td WI
+      %td United States
+      %td 12 kyu
+    %tr
+      %td Kenneth
+      %td Blake
+      %td Texas
+      %td United States
+      %td 1 kyu
+    %tr
+      %td Vivienne
+      %td Blandy
+      %td Oregon
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Andreas
+      %td Boerner
+      %td Colorado
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Jon
+      %td Boley
+      %td Washington
+      %td United States
+      %td 5 dan
+    %tr
+      %td frank
+      %td brown
+      %td Washington
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Richard
+      %td Brown
+      %td Wisconsin
+      %td United States
+      %td 3 kyu
+    %tr
+      %td Brad
+      %td Cable
+      %td Illinois
+      %td United States
+      %td 13 kyu
+    %tr
+      %td David
+      %td Canon
+      %td Wisconsin
+      %td United States
+      %td Non-Player
+    %tr
+      %td Jack
+      %td Cary
+      %td Vermont
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Eva
+      %td Casey
+      %td Massachusetts
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Tony
+      %td Cha
+      %td Georgia
+      %td United States
+      %td 4 dan
+    %tr
+      %td Samantha
+      %td Chang
+      %td Illinois
+      %td United States
+      %td 25 kyu
+    %tr
+      %td Adam
+      %td Chase
+      %td Wisconsin
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Zhaonian
+      %td Chen
+      %td New Jersey
+      %td United States
+      %td 7 dan
+    %tr
+      %td Di
+      %td Chen
+      %td New Jersey
+      %td United States
+      %td Non-Player
+    %tr
+      %td Cong
+      %td Chen
+      %td Illinois
+      %td United States
+      %td 1 dan
+    %tr
+      %td Jing
+      %td Chen
+      %td New Jersey
+      %td United States
+      %td Non-Player
+    %tr
+      %td Yong
+      %td Chen
+      %td New York
+      %td United States
+      %td 4 dan
+    %tr
+      %td Haeree
+      %td Choi
+      %td California
+      %td United States
+      %td Non-Player
+    %tr
+      %td Daniel
+      %td CHOU
+      %td Virginia
+      %td United States
+      %td 6 dan
+    %tr
+      %td Yolanda
+      %td Chow
+      %td New Jersey
+      %td United States
+      %td Non-Player
+    %tr
+      %td Stephen
+      %td Colburn
+      %td New York
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Jim
+      %td Conyngham
+      %td Texas
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Bob
+      %td Crites
+      %td Pennsylvania
+      %td United States
+      %td 6 kyu
+    %tr
+      %td John
+      %td Crossman
+      %td New York
+      %td United States
+      %td 11 kyu
+    %tr
+      %td Joseph
+      %td Cua
+      %td New Jersey
+      %td United States
+      %td 9 kyu
+    %tr
+      %td Vladimir
+      %td Danek
+      %td
+      %td Czech Republic
+      %td 5 dan
+    %tr
+      %td Lenka
+      %td Dankova
+      %td
+      %td Czech Republic
+      %td 4 kyu
+    %tr
+      %td Fredrick
+      %td Davis
+      %td
+      %td United States
+      %td 9 kyu
+    %tr
+      %td Susan
+      %td De Vos
+      %td Wisconsin
+      %td United States
+      %td 9 kyu
+    %tr
+      %td Cory
+      %td Dissinger
+      %td Pennsylvania
+      %td United States
+      %td 13 kyu
+    %tr
+      %td Conor
+      %td Dubois
+      %td Wisconsin
+      %td United States
+      %td 1 dan
+    %tr
+      %td Sherrie
+      %td Echols
+      %td Minnesota
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Elaine
+      %td Ehrlich
+      %td Virginia
+      %td United States
+      %td Non-Player
+    %tr
+      %td Robert
+      %td Ehrlich
+      %td Virginia
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Kendra
+      %td Elliston
+      %td Massachusetts
+      %td United States
+      %td Non-Player
+    %tr
+      %td Jasper
+      %td Emerton
+      %td Tennessee
+      %td United States
+      %td 2 dan
+    %tr
+      %td Mario
+      %td Espinoza
+      %td New Mexico
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Arnold
+      %td Eudell
+      %td Maryland
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Kent
+      %td Evenson
+      %td Colorado
+      %td United States
+      %td 1 dan
+    %tr
+      %td Samantha
+      %td Fede
+      %td Maryland
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Kazuko
+      %td Funakoshi
+      %td Ontario
+      %td Canada
+      %td 2 dan
+    %tr
+      %td James
+      %td Funk
+      %td Pennsylvania
+      %td United States
+      %td 2 dan
+    %tr
+      %td Scott
+      %td Gagnon
+      %td Ontario
+      %td Canada
+      %td 4 kyu
+    %tr
+      %td Carol
+      %td Gao
+      %td California
+      %td United States
+      %td Non-Player
+    %tr
+      %td Chris
+      %td Garlock
+      %td Maryland
+      %td United States
+      %td 3 dan
+    %tr
+      %td Robert
+      %td Gilman
+      %td New Mexico
+      %td United States
+      %td 6 kyu
+    %tr
+      %td John
+      %td Gipson
+      %td Maryland
+      %td United States
+      %td 5 kyu
+    %tr
+      %td David
+      %td Goeke
+      %td California
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Zachary
+      %td Gormley
+      %td Utah
+      %td United States
+      %td 1 dan
+    %tr
+      %td Jonathan
+      %td Green
+      %td Maine
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Benjamin
+      %td Gunby
+      %td Massachusetts
+      %td United States
+      %td 2 kyu
+    %tr
+      %td William
+      %td Gundberg
+      %td Arizona
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Shuman
+      %td Guo
+      %td Georgia
+      %td United States
+      %td 30 kyu
+    %tr
+      %td Andrew
+      %td Hall
+      %td California
+      %td United States
+      %td 1 dan
+    %tr
+      %td Billy
+      %td Hand
+      %td Illinois
+      %td United States
+      %td 9 kyu
+    %tr
+      %td Joshua
+      %td Haney
+      %td Maryland
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Todd
+      %td Heidenreich
+      %td Maryland
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Raymond
+      %td Heitmann
+      %td Texas
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Nathan
+      %td Hess
+      %td Texas
+      %td United States
+      %td 13 kyu
+    %tr
+      %td Nobuaki
+      %td Hirose
+      %td
+      %td Japan
+      %td 2 dan
+    %tr
+      %td Eileen
+      %td Hlavka
+      %td California
+      %td United States
+      %td 8 kyu
+    %tr
+      %td Jim
+      %td Hlavka
+      %td California
+      %td United States
+      %td 1 kyu
+    %tr
+      %td Chris
+      %td Hlavka
+      %td California
+      %td United States
+      %td 14 kyu
+    %tr
+      %td Jeffrey
+      %td Horn
+      %td California
+      %td United States
+      %td 1 dan
+    %tr
+      %td Hua-Chen
+      %td Hsu
+      %td
+      %td Taiwan
+      %td Non-Player
+    %tr
+      %td Xiaocheng
+      %td Hu
+      %td
+      %td Germany
+      %td 6 dan
+    %tr
+      %td Alan
+      %td Huang
+      %td New Jersey
+      %td United States
+      %td 7 dan
+    %tr
+      %td Daqian
+      %td Huang
+      %td New Jersey
+      %td United States
+      %td 4 dan
+    %tr
+      %td Lee
+      %td Huynh
+      %td Illinois
+      %td United States
+      %td 2 dan
+    %tr
+      %td Inseong
+      %td Hwang
+      %td
+      %td France
+      %td 7 dan
+    %tr
+      %td Susumu
+      %td Hyodo
+      %td
+      %td Japan
+      %td 3 dan
+    %tr
+      %td Shunichi
+      %td Hyodo
+      %td
+      %td Japan
+      %td 6 dan
+    %tr
+      %td Makiko
+      %td Igushi
+      %td
+      %td Japan
+      %td 3 kyu
+    %tr
+      %td Satoru
+      %td Inoue
+      %td Illinois
+      %td United States
+      %td 1 dan
+    %tr
+      %td Bart
+      %td Jacob
+      %td Texas
+      %td United States
+      %td 3 kyu
+    %tr
+      %td Eric
+      %td Jankowski
+      %td Idaho
+      %td United States
+      %td 2 dan
+    %tr
+      %td Richard
+      %td Jankowski
+      %td Michigan
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Zhongfan
+      %td Jian
+      %td Massachusetts
+      %td United States
+      %td 7 dan
+    %tr
+      %td Xuesong
+      %td Jiang
+      %td New Jersey
+      %td United States
+      %td Non-Player
+    %tr
+      %td Mingjiu
+      %td Jiang
+      %td California
+      %td United States
+      %td 7 pro
+    %tr
+      %td Jianian
+      %td Jin
+      %td Wisconsin
+      %td United States
+      %td 5 dan
+    %tr
+      %td Yongquan
+      %td Jin
+      %td New York
+      %td United States
+      %td 3 dan
+    %tr
+      %td Justin
+      %td Johnson
+      %td MI
+      %td United States
+      %td 3 dan
+    %tr
+      %td Benjamin
+      %td Jones
+      %td Ohio
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Daniel
+      %td Kastenholz
+      %td Wisconsin
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Masahiro
+      %td Kawaguchi
+      %td
+      %td Japan
+      %td 5 dan
+    %tr
+      %td Richard
+      %td Keay
+      %td Ohio
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Gurujeet
+      %td Khalsa
+      %td Maryland
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Yoonyoung
+      %td Kim
+      %td Quebec
+      %td Canada
+      %td 4 pro
+    %tr
+      %td Myungwan
+      %td Kim
+      %td California
+      %td United States
+      %td 8 pro
+    %tr
+      %td Hiroshi
+      %td Kimura
+      %td Shiga
+      %td Japan
+      %td 3 dan
+    %tr
+      %td Brian
+      %td Kirby
+      %td Mi
+      %td United States
+      %td 2 dan
+    %tr
+      %td Chris
+      %td Kirschner
+      %td Washington
+      %td United States
+      %td 3 dan
+    %tr
+      %td Tadafumi
+      %td Kita
+      %td
+      %td Japan
+      %td 3 dan
+    %tr
+      %td Michiko
+      %td Kobayashi
+      %td
+      %td Japan
+      %td 6 kyu
+    %tr
+      %td Kenneth
+      %td Koester, Jr
+      %td Maryland
+      %td United States
+      %td 2 dan
+    %tr
+      %td Keiko
+      %td Komoto
+      %td 7-8-11 oi
+      %td Japan
+      %td 29 kyu
+    %tr
+      %td Tadashi
+      %td Komoto
+      %td 7-8-11 oi
+      %td Japan
+      %td 5 dan
+    %tr
+      %td Barry
+      %td Kraft
+      %td Oregon
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Christian
+      %td Kühner
+      %td
+      %td Germany
+      %td 3 dan
+    %tr
+      %td Greg
+      %td Kulevich
+      %td Illinois
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Steffen
+      %td Kurz
+      %td Minnesota
+      %td United States
+      %td 3 kyu
+    %tr
+      %td Jay
+      %td Lampert
+      %td Pennsylvania
+      %td United States
+      %td 3 dan
+    %tr
+      %td Lester
+      %td Lanphear
+      %td California
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Joshua
+      %td Lee
+      %td Virginia
+      %td United States
+      %td 6 dan
+    %tr
+      %td Mark
+      %td Lee
+      %td California
+      %td United States
+      %td 7 dan
+    %tr
+      %td Hajin
+      %td Lee
+      %td California
+      %td United States
+      %td 4 pro
+    %tr
+      %td Michael
+      %td Lepore
+      %td Virginia
+      %td United States
+      %td 3 dan
+    %tr
+      %td YI NING
+      %td Leu
+      %td California
+      %td United States
+      %td Non-Player
+    %tr
+      %td Karoline
+      %td Li
+      %td California
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Xing Tong
+      %td Li
+      %td New York
+      %td United States
+      %td 30 kyu
+    %tr
+      %td Tao
+      %td Li
+      %td California
+      %td United States
+      %td 1 dan
+    %tr
+      %td Cathy Chen Shuo
+      %td Li
+      %td British Columbia
+      %td Canada
+      %td 1 pro
+    %tr
+      %td Charles
+      %td Liang
+      %td Indiana
+      %td United States
+      %td 25 kyu
+    %tr
+      %td Judith
+      %td Lipofsky
+      %td Florida
+      %td United States
+      %td Non-Player
+    %tr
+      %td Barton
+      %td Lipofsky
+      %td FL
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Mark
+      %td Long
+      %td Tennessee
+      %td United States
+      %td 1 dan
+    %tr
+      %td Jeffrey
+      %td Losapio
+      %td New Jersey
+      %td United States
+      %td 3 kyu
+    %tr
+      %td I-han
+      %td Lui
+      %td Maryland
+      %td United States
+      %td 7 dan
+    %tr
+      %td Daniel
+      %td Maas
+      %td California
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Cat
+      %td Mai
+      %td Massachusetts
+      %td United States
+      %td 3 kyu
+    %tr
+      %td William
+      %td Maier
+      %td New Mexico
+      %td United States
+      %td 3 kyu
+    %tr
+      %td Melanie
+      %td Manion
+      %td Wisconsin
+      %td United States
+      %td Non-Player
+    %tr
+      %td Jamie
+      %td Marinic
+      %td Ontario
+      %td Canada
+      %td 1 kyu
+    %tr
+      %td Matthew
+      %td Matlock
+      %td Missouri
+      %td United States
+      %td 3 dan
+    %tr
+      %td Mamoru
+      %td Matsumoto
+      %td Osaka-Fu
+      %td Japan
+      %td 3 dan
+    %tr
+      %td Reinhardt
+      %td Messerschmidt
+      %td
+      %td United Kingdom
+      %td 1 dan
+    %tr
+      %td Wanda
+      %td Metcalf
+      %td Massachusetts
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Amanda
+      %td Miller
+      %td Massachusetts
+      %td United States
+      %td 8 kyu
+    %tr
+      %td Richard
+      %td Moseson
+      %td New York
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Markar
+      %td Nahabedian
+      %td Massachusetts
+      %td United States
+      %td 12 kyu
+    %tr
+      %td Yasuhiro
+      %td Nakano
+      %td
+      %td Japan
+      %td 9 pro
+    %tr
+      %td Mayumi
+      %td Nakano
+      %td
+      %td Japan
+      %td 20 kyu
+    %tr
+      %td Akiko
+      %td Nakata
+      %td Virginia
+      %td United States
+      %td Non-Player
+    %tr
+      %td Kazuko
+      %td Nakata
+      %td
+      %td Japan
+      %td Non-Player
+    %tr
+      %td Yoshitomo
+      %td Nakata
+      %td Tokyo
+      %td Japan
+      %td 1 kyu
+    %tr
+      %td Michael
+      %td Neigebauer
+      %td Illinois
+      %td United States
+      %td 3 kyu
+    %tr
+      %td Richard
+      %td Newman
+      %td Colorado
+      %td United States
+      %td 9 kyu
+    %tr
+      %td Li Li
+      %td Niu
+      %td NA
+      %td Japan
+      %td 5 pro
+    %tr
+      %td Satoshi
+      %td Numano
+      %td
+      %td Japan
+      %td 1 dan
+    %tr
+      %td Chanseok
+      %td Oh
+      %td Washington
+      %td United States
+      %td 5 dan
+    %tr
+      %td Moonhun
+      %td Oh
+      %td Virginia
+      %td United States
+      %td 1 dan
+    %tr
+      %td Yoko
+      %td Ohashi
+      %td
+      %td Japan
+      %td 6 kyu
+    %tr
+      %td Andrew
+      %td Okun
+      %td California
+      %td United States
+      %td 1 dan
+    %tr
+      %td Andy
+      %td Olsen
+      %td Texas
+      %td United States
+      %td 3 dan
+    %tr
+      %td Kunio
+      %td One
+      %td
+      %td Japan
+      %td 1 dan
+    %tr
+      %td David
+      %td Orr
+      %td Michigan
+      %td United States
+      %td 8 kyu
+    %tr
+      %td Sojung
+      %td Park
+      %td New Jersey
+      %td United States
+      %td 25 kyu
+    %tr
+      %td Matt
+      %td Payton
+      %td Maryland
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Peilung
+      %td Peng
+      %td Texas
+      %td United States
+      %td 4 dan
+    %tr
+      %td Antonina
+      %td Perez-Lopez
+      %td Virginia
+      %td United States
+      %td 18 kyu
+    %tr
+      %td Maxwell
+      %td Peterson
+      %td Minnesota
+      %td United States
+      %td 6 dan
+    %tr
+      %td James
+      %td Pickett
+      %td Maryland
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Pauline
+      %td Pohl
+      %td Illinois
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Eric
+      %td Proces
+      %td Wisconsin
+      %td United States
+      %td 15 kyu
+    %tr
+      %td Mingming
+      %td Qi
+      %td Seoul
+      %td South Korea
+      %td 30 kyu
+    %tr
+      %td Robert
+      %td Qi
+      %td New Jersey
+      %td United States
+      %td 8 kyu
+    %tr
+      %td Edward
+      %td Ream
+      %td Wisconsin
+      %td United States
+      %td 1 dan
+    %tr
+      %td John
+      %td Redford
+      %td Texas
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Tyler
+      %td Reeson
+      %td Wi
+      %td United States
+      %td 11 kyu
+    %tr
+      %td Neil
+      %td Ritter
+      %td Massachusetts
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Austin
+      %td Robinson
+      %td New York
+      %td United States
+      %td 4 kyu
+    %tr
+      %td David
+      %td Rockwell
+      %td Illinois
+      %td United States
+      %td 6 kyu
+    %tr
+      %td David
+      %td Rolsky
+      %td MN
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Brendan
+      %td Roof
+      %td Washington
+      %td United States
+      %td 1 kyu
+    %tr
+      %td Bradley
+      %td Rose
+      %td Illinois
+      %td United States
+      %td 13 kyu
+    %tr
+      %td Gregory
+      %td Rosenblatt
+      %td Ontario
+      %td Canada
+      %td 5 dan
+    %tr
+      %td Mark
+      %td Rubenstein
+      %td Illinois
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Larry
+      %td Russ
+      %td New Jersey
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Kacey
+      %td Saff
+      %td Colorado
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Kenneth
+      %td Sammon
+      %td New Hampshire
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Joel
+      %td Sanet
+      %td Florida
+      %td United States
+      %td 1 dan
+    %tr
+      %td Marc
+      %td Sarrel
+      %td California
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Reiko
+      %td Sata
+      %td
+      %td Japan
+      %td 1 dan
+    %tr
+      %td Mitchell
+      %td Schmeisser
+      %td Pennsylvania
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Dan
+      %td Schmidt
+      %td Massachusetts
+      %td United States
+      %td 3 kyu
+    %tr
+      %td George
+      %td Schmitten
+      %td Washington
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Lee
+      %td Schumacher
+      %td California
+      %td United States
+      %td 1 dan
+    %tr
+      %td Peter
+      %td Schumer
+      %td Vermont
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Laura (Lisa)
+      %td Scott
+      %td Illinois
+      %td United States
+      %td 2 kyu
+    %tr
+      %td James
+      %td Sedgwick
+      %td Ontario
+      %td Canada
+      %td 6 dan
+    %tr
+      %td Alicia M
+      %td Seifrid
+      %td Illinois
+      %td United States
+      %td 13 kyu
+    %tr
+      %td Jing( Jennie)
+      %td Shen
+      %td California
+      %td United States
+      %td 2 pro
+    %tr
+      %td Nick
+      %td Sibicky
+      %td WA
+      %td United States
+      %td 4 dan
+    %tr
+      %td Debbie
+      %td Siemon
+      %td Georgia
+      %td United States
+      %td 1 dan
+    %tr
+      %td Richard
+      %td Simon
+      %td New York
+      %td United States
+      %td 3 kyu
+    %tr
+      %td Solomon
+      %td Smilack
+      %td Colorado
+      %td United States
+      %td 3 dan
+    %tr
+      %td Garrett
+      %td Smith
+      %td Virginia
+      %td United States
+      %td 10 kyu
+    %tr
+      %td Richard
+      %td Solberg
+      %td Illinois
+      %td United States
+      %td 2 kyu
+    %tr
+      %td Myron
+      %td Souris
+      %td Missouri
+      %td United States
+      %td 1 kyu
+    %tr
+      %td Laura
+      %td Sparks
+      %td California
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Eli
+      %td Steiger
+      %td Ohio
+      %td United States
+      %td 18 kyu
+    %tr
+      %td Phil
+      %td Straus
+      %td Pennsylvania
+      %td United States
+      %td 1 dan
+    %tr
+      %td Xian
+      %td Sun
+      %td
+      %td China
+      %td Non-Player
+    %tr
+      %td Fumio
+      %td Suzuki
+      %td
+      %td Japan
+      %td 3 dan
+    %tr
+      %td Daiju
+      %td Takahashi
+      %td New Jersey
+      %td United States
+      %td 30 kyu
+    %tr
+      %td Vincent
+      %td Tam
+      %td Texas
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Tomikazu
+      %td Tatsumi
+      %td
+      %td Japan
+      %td 1 dan
+    %tr
+      %td Emi
+      %td Tatsumi
+      %td
+      %td Japan
+      %td 30 kyu
+    %tr
+      %td Vincent
+      %td Tcheng
+      %td California
+      %td United States
+      %td 4 kyu
+    %tr
+      %td Justin
+      %td Teng
+      %td Maryland
+      %td United States
+      %td 6 dan
+    %tr
+      %td Theodore
+      %td Terpstra
+      %td Ca
+      %td United States
+      %td 5 kyu
+    %tr
+      %td Schurter
+      %td Terri
+      %td New Jersey
+      %td United States
+      %td 10 kyu
+    %tr
+      %td Jason
+      %td Thomason
+      %td Utah
+      %td United States
+      %td 1 kyu
+    %tr
+      %td Tevis
+      %td Tsai
+      %td Md
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Anurag
+      %td Varma
+      %td North Dakota
+      %td United States
+      %td 3 kyu
+    %tr
+      %td Ashish
+      %td Varma
+      %td Minnesota
+      %td United States
+      %td 5 dan
+    %tr
+      %td Jaya
+      %td Varma
+      %td North Dakota
+      %td United States
+      %td 30 kyu
+    %tr
+      %td Amiy
+      %td Varma
+      %td North Dakota
+      %td United States
+      %td 30 kyu
+    %tr
+      %td Eric
+      %td Wainwright
+      %td Colorado
+      %td United States
+      %td 1 dan
+    %tr
+      %td Xinyu
+      %td Wang
+      %td Illinois
+      %td United States
+      %td 1 dan
+    %tr
+      %td Qian
+      %td Wang
+      %td New York
+      %td United States
+      %td Non-Player
+    %tr
+      %td Kuan
+      %td Wang
+      %td New Jersey
+      %td United States
+      %td Non-Player
+    %tr
+      %td Yinli
+      %td Wang
+      %td Indiana
+      %td United States
+      %td 7 dan
+    %tr
+      %td Steven
+      %td Wayne
+      %td Illinois
+      %td United States
+      %td 15 kyu
+    %tr
+      %td David
+      %td Weimer
+      %td Wisconsin
+      %td United States
+      %td 2 dan
+    %tr
+      %td Paul
+      %td Weiner
+      %td Minnesota
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Xiangying
+      %td Wen
+      %td New York
+      %td United States
+      %td Non-Player
+    %tr
+      %td Dennis
+      %td Wheeler
+      %td Washington
+      %td United States
+      %td 7 kyu
+    %tr
+      %td Dave
+      %td Whipp
+      %td California
+      %td United States
+      %td 6 kyu
+    %tr
+      %td Nicholas
+      %td Wilmes
+      %td Washington
+      %td United States
+      %td 3 kyu
+    %tr
+      %td Ryan
+      %td Woolgar
+      %td Wisconsin
+      %td United States
+      %td 9 kyu
+    %tr
+      %td Neal
+      %td Wright
+      %td Oregon
+      %td United States
+      %td 5 kyu
+    %tr
+      %td LingLing
+      %td Wu
+      %td Beijing
+      %td China
+      %td Non-Player
+    %tr
+      %td Weiwei
+      %td wu
+      %td New Jersey
+      %td United States
+      %td 30 kyu
+    %tr
+      %td Nqua
+      %td Xiong
+      %td Minnesota
+      %td United States
+      %td 2 dan
+    %tr
+      %td Lang
+      %td Xu
+      %td Wisconsin
+      %td United States
+      %td 4 dan
+    %tr
+      %td Noriko
+      %td Yamamoto
+      %td
+      %td Japan
+      %td 3 kyu
+    %tr
+      %td Yilun
+      %td Yang
+      %td California
+      %td United States
+      %td 7 pro
+    %tr
+      %td Mingming
+      %td Yin
+      %td New York
+      %td United States
+      %td 1 pro
+    %tr
+      %td Peter
+      %td Zhang
+      %td New Jersey
+      %td United States
+      %td 3 dan
+    %tr
+      %td Qingbo
+      %td Zhang
+      %td Virginia
+      %td United States
+      %td 5 dan
+    %tr
+      %td Na
+      %td Zhang
+      %td
+      %td United States
+      %td Non-Player
+    %tr
+      %td Rongli
+      %td Zhang
+      %td
+      %td China
+      %td Non-Player
+    %tr
+      %td Alice
+      %td Zhang
+      %td
+      %td China
+      %td 1 dan
+    %tr
+      %td Wenguang
+      %td Zhao
+      %td California
+      %td United States
+      %td 6 dan
+    %tr
+      %td Hongkui
+      %td Zheng
+      %td California
+      %td United States
+      %td 7 dan
+    %tr
+      %td Li
+      %td Zheng
+      %td New York
+      %td United States
+      %td Non-Player
+    %tr
+      %td Afa
+      %td Zhou
+      %td New York
+      %td United States
+      %td 1 dan
+    %tr
+      %td Neil
+      %td Zod
+      %td Pennsylvania
+      %td United States
+      %td 11 kyu
+
+-# - if @year.registration_phase == "closed"
+  -# %p Registration for the #{@year.year} Go Congress has not yet begun.
+
+-# - else
+  -# - if @who_is_coming.count > 0
+    -# %p
+      -# There are #{ @who_is_coming.count } people registered, including
+      -# #{@who_is_coming.kyu_count} kyu players, #{@who_is_coming.dan_count} dan
+      -# players, and #{pluralize(@who_is_coming.pro_count, 'pro')}.
+      -# Also, #{@who_is_coming.unregistered_count} other people have not finished
+      -# their registration.  A payment of at least $70 must be made before
+      -# attendees of an account can appear on this list.  Attendees with a child
+      -# registration plan will not appear on this list.
+
+    -# - unless anyone_signed_in?
+      -# %p
+        -# Are you coming?  Please
+        -# = link_to 'register!', new_user_registration_path
+
+    -# %table.semantic.fullwidth.zebra
+      -# %thead
+        -# %tr
+          -# %th
+          -# - %w[given_name family_name rank country created_at].each do |c|
+            -# - drn = (c == params[:sort]) ? @who_is_coming.opposite_direction : :asc
+            -# %th= link_to trl_attr(:attendee, c), :sort => c, :direction => drn
+      -# %tbody
+        -# - @who_is_coming.attendees.each_with_index do |a,i|
+          -# %tr{:class => if a.anonymous then "understated" end }
+            -# %td= i + 1
+            -# %td= a.given_name_anonymized
+            -# %td= a.family_name_anonymized
+            -# %td= a.rank_name
+            -# %td= a.anonymize_attribute :country
+            -# %td= a.created_at.to_date.to_formatted_s(:rfc822)
+  -# - else
+    -# %p
+      -# This list is currently not available.


### PR DESCRIPTION
Since this year's Congress (2019) is using a separate system for
registration, the dynamic "Who's Coming?" page isn't accurate. There's
work purportedly underway in syncing them, but we needed to put up
information in the meantime. This adds a static table generated
separately from a spreadhseet and comments out the page's normal dynamic
functionality.