### PR TITLE
Modify registration to get values from Members API

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -178,9 +178,11 @@ table .numeric {
 img.thin-border {
   border: 1px solid black;
 }
-.initially_hidden {
+
+.initially-hidden {
   display: none;
 }
+
 .hardwrap {
   /* These are technically the same, but use both */
   overflow-wrap: break-word;
@@ -488,6 +490,10 @@ Also applies to contents of dialogs. */
         background-color: $nav-bg-highlight-color;
       }
     }
+
+    + #footer {
+      border-top: 0;
+    }
   }
 
   /* Nested lists look better without padding */
@@ -760,6 +766,7 @@ fieldset.wordy-questions .aligned-with-input {
 
 /* Footer */
 #footer {
+  border-top: 1em solid $nav-bg-color;
   margin: 0 auto;
   padding: ($spacing-unit / 2) $spacing-unit;
   display: flex;
@@ -801,9 +808,6 @@ button,
   color: $color;
   cursor: pointer;
   display: inline-block;
-  font: {
-    // size: 18px;
-  }
   padding: 5px 10px;
   position: relative;
   text-decoration: none;
@@ -850,4 +854,45 @@ select {
 
 .intl-tel-input {
   margin-right: 10px;
+}
+
+#aga_member_search {
+  .search-input {
+    label {
+      font-weight: bold;
+    }
+    margin: 1em 0;
+  }
+}
+
+#aga_member_search {
+  .search-results {
+    margin-bottom: 1em;
+
+    table {
+      border-collapse: collapse;
+    }
+
+    .search-result {
+      background: #eee;
+      &:hover {
+        background: hsl(50, 100%, 80%);
+      }
+
+      cursor: pointer;
+
+      td {
+        padding: 0.5em;
+      }
+
+      .aga-id {
+        opacity: 0.5;
+        text-align: right;
+      }
+
+      .full-name {
+        font-weight: bold;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,12 +1,20 @@
 /* Color scheme */
-$dark-orange: #FF9B05;
-$dark-blue: #0071BC;
-$light-blue: #64AEDE;
+$dark-orange: #ff9b05;
+$dark-blue: #0071bc;
+$light-blue: #64aede;
 
 /* Basic element styling (no classes yet) */
-* { margin: 0pt; padding: 0pt; }
-body { background-color: white; margin: 20pt; }
-hr { margin: 1em 0em 1em 0em; }
+* {
+  margin: 0pt;
+  padding: 0pt;
+}
+body {
+  background-color: white;
+  margin: 20pt;
+}
+hr {
+  margin: 1em 0em 1em 0em;
+}
 blockquote {
   font-size: 14pt;
   font-style: oblique;
@@ -22,44 +30,112 @@ legend {
   font-weight: bold;
   padding: 1em 0em 0.25em 0em;
 }
-input[type="submit"], input[type="button"] { cursor: pointer; }
+input[type="submit"],
+input[type="button"] {
+  cursor: pointer;
+}
 
 /* Font Families */
-h1, h2, h3, h4, h5, h6, legend, th { font-family: Helvetica, sans-serif; }
-body, td, p, span, div, li, hr, blockquote { font-family: Times, serif; }
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+legend,
+th {
+  font-family: Helvetica, sans-serif;
+}
+body,
+td,
+p,
+span,
+div,
+li,
+hr,
+blockquote {
+  font-family: Times, serif;
+}
 
 /* Basic font sizing */
-h1 { font-size: 18pt; }
-h2 { font-size: 14pt; }
-h3 { font-size: 12pt; }
-p, span, div, th, td { font-size: 9pt; }
+h1 {
+  font-size: 18pt;
+}
+h2 {
+  font-size: 14pt;
+}
+h3 {
+  font-size: 12pt;
+}
+p,
+span,
+div,
+th,
+td {
+  font-size: 9pt;
+}
 
 /* Truly basic classes that could apply anywhere -Jared 12/30/10 */
-.fullwidth { width: 100%; }
-.inline { display: inline; }
-.smalltext { font-size: 12pt; }
-th { text-align: left; }
-th.row { vertical-align: top; }
-table .numeric { text-align: right; }
-.align-center { text-align: center; }
-.align-right { text-align: right; }
-img.thin-border { border: 1pt solid black; }
-.initially_hidden { display: none; }
-.clear { clear: both; }
-.page-break-after { page-break-after: always; }
+.fullwidth {
+  width: 100%;
+}
+.inline {
+  display: inline;
+}
+.smalltext {
+  font-size: 12pt;
+}
+th {
+  text-align: left;
+}
+th.row {
+  vertical-align: top;
+}
+table .numeric {
+  text-align: right;
+}
+.align-center {
+  text-align: center;
+}
+.align-right {
+  text-align: right;
+}
+img.thin-border {
+  border: 1pt solid black;
+}
+.initially-hidden {
+  display: none;
+}
+.clear {
+  clear: both;
+}
+.page-break-after {
+  page-break-after: always;
+}
 
 /* Use this class to pad flow elements (eg. div, form) -Jared 4/9/11 */
-.flow-padding { padding: 8pt 0pt; }
+.flow-padding {
+  padding: 8pt 0pt;
+}
 
 /* Print-specific styles */
-p, table, h2 { padding: 0.5em 0em; }
-td, th { padding-right: 1em; }
+p,
+table,
+h2 {
+  padding: 0.5em 0em;
+}
+td,
+th {
+  padding-right: 1em;
+}
 .narrow-column {
   display: inline-block;
   padding: 0pt 20pt 0pt 0pt;
   vertical-align: top;
   width: 100pt;
-  h2 { padding: 20pt 0pt 0pt 10pt;}
+  h2 {
+    padding: 20pt 0pt 0pt 10pt;
+  }
 }
 .wide-column {
   display: inline-block;
@@ -67,14 +143,23 @@ td, th { padding-right: 1em; }
   width: 415pt;
 }
 tr.total {
-  th, td {
+  th,
+  td {
     border-top: 1px solid black;
     padding-top: 0.25em;
   }
 }
-.logo { float: left; padding-right: 20pt; }
-.registration-sheet { page-break-after: always; }
+.logo {
+  float: left;
+  padding-right: 20pt;
+}
+.registration-sheet {
+  page-break-after: always;
+}
 
 /* Paper size is US Letter Portraint with half-inch gutters */
 /* 7.5 inches = 540 PostScript points */
-.paper-size-is-letter { overflow:hidden; width: 540pt; }
+.paper-size-is-letter {
+  overflow: hidden;
+  width: 540pt;
+}

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,23 @@
+require 'open-uri'
+
+class ApiController < ApplicationController
+  API_URL = "https://www.usgo.org/mm/api/members/"
+
+  def search_members
+    print('search members')
+    print(params)
+    print('api key: ' + ENV['AGA_MEMBERS_API_KEY'])
+
+    if !!(params[:search] =~ /^[1-9]+[0-9]*$/)
+      action = "#{params[:search]}?api_key=#{ENV['AGA_MEMBERS_API_KEY']}"
+    else
+      action = "all?query=#{ERB::Util.url_encode('type != chapter ')}#{params[:search]}&limit=10&api_key=#{ENV['AGA_MEMBERS_API_KEY']}"
+    end
+
+    print(action)
+    buffer = open("#{API_URL}#{action}").read
+    result = JSON.parse(buffer)
+
+    render json: result
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -7,6 +7,55 @@ class RegistrationsController < ApplicationController
     attendee.year = @year.year
     @registration = Registration.new(current_user, attendee)
     expose_legacy_form_vars # TODO: don't!
+
+    if params.has_key?(:aga_id)
+      # Get member info from the API
+      apiUrl = "https://www.usgo.org/mm/api/members/"
+      action = "#{params[:aga_id]}?api_key=#{ENV['AGA_MEMBERS_API_KEY']}"
+
+      begin
+        buffer = open("#{apiUrl}#{action}").read
+        result = JSON.parse(buffer)
+
+        if result['success']
+          # Pre-fill attendee values with AGA Member Info
+          i = result['payload']['row']
+          attendee.given_name = i['given_names']
+          attendee.family_name = i['family_name']
+
+          # Grab the first letter of gender
+          # Ex: 'female' => 'f'
+          attendee.gender = i['gender'][0] rescue ''
+
+          attendee.birth_date = i['dob']
+          attendee.aga_id = i['member_id']
+          attendee.phone = i['phone']
+          attendee.local_phone = i['phone']
+          attendee.email = i['email']
+          attendee.state = i['state']
+
+          # Minimum rating is -30 (30k)
+          attendee.rank = [i['rating'].to_i, -30].max.to_s
+
+          if (i['country'] == 'USA')
+            attendee.country = 'US'
+          else
+            # Try to get the country code from the site constants
+            found = COUNTRIES.detect {|country| country[0] == i['country']}
+            if found
+              attendee.country = found[1]
+            end
+          end
+        end
+
+        rescue OpenURI::HTTPError
+          # No worries! We just won't pre-fill any values.
+      end
+
+      render :new
+    else
+      render :aga_member_search
+    end
   end
 
   def create

--- a/app/views/2018/registrations/_player_info.html.haml
+++ b/app/views/2018/registrations/_player_info.html.haml
@@ -6,14 +6,6 @@
       = link_to 'What is my AGA rank?', '#', :id => 'open_dialog_rank'
 
   .field
-    = f.label :aga_id, 'AGA ID'
-    = f.number_field :aga_id, :size => 8, :min => 1, :step => 1
-    %span.smalltext
-      No
-      = link_to 'AGA ID?', '#', :id => 'open_dialog_aga_id'
-      &nbsp; Leave it blank.
-
-  .field
     = f.label :will_play_in_us_open
     %div
       %label

--- a/app/views/registrations/_activities.html.haml
+++ b/app/views/registrations/_activities.html.haml
@@ -7,8 +7,7 @@
 
   %p
     Prices and times are subject to change.
-    Questions? Contact the
-    = link_to "registrar.", contacts_path
+    Questions? Contact the #{link_to "registrar", contacts_path}.
 
   %table.semantic.zebra.fullwidth
     %thead

--- a/app/views/registrations/_form.html.haml
+++ b/app/views/registrations/_form.html.haml
@@ -8,7 +8,6 @@
 = form_for(@registration) do |f|
   = f.hidden_field :user_id
   = hidden_field_tag 'type', params[:type]
-
   = render :partial => 'shared/error_messages', :locals => { :resource => @registration }
   = render :partial => "/#{@year.year}/registrations/personal_info", :locals => { :f => f } rescue render :partial => 'personal_info', :locals => { :f => f }
   = render :partial => "/#{@year.year}/registrations/shirt_info", :locals => { :f => f } rescue render :partial => 'shirt_info', :locals => { :f => f }

--- a/app/views/registrations/_personal_info.html.haml
+++ b/app/views/registrations/_personal_info.html.haml
@@ -4,6 +4,7 @@
     = f.text_field :given_name, :placeholder => 'Given Name', :size => 15
     = f.text_field :alternate_name, :placeholder => '(Alternate Name)', :size => 15
     = f.text_field :family_name, :placeholder => 'Family Name', :size => 15
+
   .field.flex
     %div.field-key
       = f.label :anonymous, "Anonymous"

--- a/app/views/registrations/_plans.haml
+++ b/app/views/registrations/_plans.haml
@@ -15,8 +15,7 @@
   Mark the checkboxes (#{disabled_checkbox})
   below #{" or enter quantities" if @registration.show_quantity_instructions}.
 
-  Questions? Contact the
-  = link_to 'registrar.', contacts_path
+  Questions? Contact the #{link_to 'registrar', contacts_path}.
 
 - if @registration.plans_by_category.count > 0
   - @registration.plans_by_category.each do |cat, plans|

--- a/app/views/registrations/_player_info.html.haml
+++ b/app/views/registrations/_player_info.html.haml
@@ -8,21 +8,11 @@
       %span.smalltext
         = link_to 'What is my AGA rank?', '#', :id => 'open_dialog_rank'
 
-  .field.flex
-    %div.field-key
-      = f.label :aga_id, 'AGA ID'
-
-    %div.field-value
-      = f.number_field :aga_id, :size => 8, :min => 1, :step => 1
-
-      %div.field-help-text
-        No
-        = link_to 'AGA ID?', '#', :id => 'open_dialog_aga_id'
-        &nbsp; Leave it blank.
+  = hidden_field_tag :aga_id
 
   .field.flex
     %div.field-key
-      = f.label :will_play_in_us_open
+      = f.label :will_play_in_us_open, trl_attr(:attendee, :will_play_in_us_open)
 
     %div.field-value
       %label

--- a/app/views/registrations/aga_member_search.html.haml
+++ b/app/views/registrations/aga_member_search.html.haml
@@ -4,8 +4,9 @@
     %p If this attendee is an AGA Member, please locate their member record using the search below. You can search by name or by ID.
 
     %div.search-input
-      %label{ :for => "aga_member_search_input" } Search:
-      %input{ :autofocus => true, :placeholder => "Go Seigen" }
+      %label{ :for => "aga_member_search_input" }
+        Search:
+      %input#aga_member_search_input{ :autofocus => true, :placeholder => "Go Seigen" }
 
       %p.initially-hidden.searching-message Searching&hellip;
 

--- a/app/views/registrations/aga_member_search.html.haml
+++ b/app/views/registrations/aga_member_search.html.haml
@@ -1,0 +1,91 @@
+%fieldset
+  %div#aga_member_search
+    %h3 AGA Membership
+    %p If this attendee is an AGA Member, please locate their member record using the search below. You can search by name or by ID.
+
+    %div.search-input
+      %label{ :for => "aga_member_search_input" } Search:
+      %input{ :autofocus => true, :placeholder => "Go Seigen" }
+
+      %p.initially-hidden.searching-message Searching&hellip;
+
+    %div.search-results
+
+  %div#not_an_aga_member
+    %p
+      = link_to "This attendee is not an AGA member", url_for(request.params.merge({:aga_id => 'none'})), class: 'button'
+    %div.help-text
+      %p AGA Membership is required to play in AGA tournaments, but not for other Congress activities.
+      %p You can #{link_to "join the AGA", "https://www.usgo.org/members/join"} or manage your membership at the #{link_to "AGA Members / Chapters Area", "https://www.usgo.org/members"}.
+
+
+:javascript
+  const memberSearch = document.getElementById('aga_member_search');
+  const searchResultsContainer = memberSearch.querySelector('.search-results');
+  const input = memberSearch.querySelector('input');
+  const searchingMessage = memberSearch.querySelector('.searching-message');
+  console.log('searchingMessage', searchingMessage)
+
+  // A generic debouncer
+  let debounceTimeout;
+  const debounce = (fn, ms = 100) => {
+    clearTimeout(debounceTimeout);
+    debounceTimeout = setTimeout(fn, ms)
+  }
+
+  // Search the AGA Members app for either a name or ID
+  const searchMembers = async () => {
+    if (!input.value) {
+      return;
+    }
+
+    const url = `/api/mm/members/${encodeURIComponent(input.value)}`;
+    const options = {
+      method: 'GET'
+    };
+
+    const response = await fetch(url, options);
+    const { payload } = await response.json();
+
+    const results = payload.rows || [payload.row];
+
+    if (results.length) {
+      displayResults(results)
+    }
+  }
+
+  const displayResults = results => {
+    displaySearchingMessage(false);
+    searchResultsContainer.innerHTML = '';
+    const searchResultsTable = document.createElement('table');
+
+    results.forEach(result => {
+      const row = document.createElement('tr');
+      row.classList.add('search-result');
+      row.innerHTML = [
+        `<td class="aga-id">${result.member_id}</td>`,
+        `<td class="full-name">${result.full_name}</td>`,
+        `<td class="rating">${result.rating ? `Rating: ${result.rating}`: ''}</td>`
+      ].join('');
+
+      row.addEventListener('click', () => selectResult(result.member_id))
+      searchResultsTable.appendChild(row);
+      searchResultsContainer.appendChild(searchResultsTable);
+    });
+  }
+
+  const selectResult = memberId => {
+    // Append the selected memberId to the current URL, so the router will take
+    // us to the next step
+    window.location.href += `&aga_id=${memberId}`
+  }
+
+  // Toggle a "searching" message to make clear that something is happening once
+  // a user types
+  const displaySearchingMessage = (state = true) => {
+    searchingMessage.classList.toggle('initially-hidden', !state);
+  }
+
+  input.addEventListener('keyup', () => debounce(searchMembers, 500));
+
+  input.addEventListener('keypress', displaySearchingMessage);

--- a/app/views/users/invoice.html.haml
+++ b/app/views/users/invoice.html.haml
@@ -1,7 +1,6 @@
 %h2 Cost Summary
 %p
-  Questions? Please contact the
-  = link_to 'registrar.', contacts_path
+  Questions? Please contact the #{link_to 'registrar', contacts_path}.
 
 %table.semantic.fullwidth.zebra
   %thead

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
         notes: "Notes"
         leave_time: "Leave"
         return_time: "Return"
-        url: 'Website'
+        url: "Website"
       attendee:
         address_1: "Address Line 1"
         address_2: "Address Line 2"
@@ -46,7 +46,7 @@ en:
         roomate_request: "Roommate Request"
         comment: "Comments"
         understand_minor: "Youth Attendance Agreement"
-        will_play_in_us_open: "Will play in US Open?"
+        will_play_in_us_open: "Will play in U.S. Open?"
       contact:
         title: "Title"
         email: "Email"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Gocongress::Application.routes.draw do
   mount StripeEvent::Engine, at: '/stripe-webhooks'
 
 
+  # proxy
+  get 'api/mm/members/:search', to: 'api#search_members'
+
 
   # Put the root route at the top so that it is matched quickly
   root :to => "home#index", :via => :get

--- a/spec/features/attendee_form_spec.rb
+++ b/spec/features/attendee_form_spec.rb
@@ -11,12 +11,19 @@ RSpec.describe 'registration form', :type => :feature do
     click_button 'Sign in'
     expect(page).to have_content('My Account')
     visit new_registration_path(year: user.year, user_id: user.id, type: 'adult')
-    expect(page).to have_content('First Attendee')
-    expect(page).to have_selector('form')
+    expect(page).to have_content('AGA Membership')
   end
 
   context 'new' do
+    it 'allows user to skip Member search' do
+      click_link 'This attendee is not an AGA member'
+      expect(page).to have_content('First Attendee')
+      expect(page).to have_selector('form')
+    end
+
     it 'saves a new attendee' do
+      click_link 'This attendee is not an AGA member'
+
       fill_in 'Given Name', with: 'Minnie'
       fill_in 'Family Name', with: 'Mouse'
       choose 'registration_gender_f'
@@ -38,12 +45,15 @@ RSpec.describe 'registration form', :type => :feature do
     end
 
     it 'shows errors when form is invalid' do
+      click_link 'This attendee is not an AGA member'
       fill_in 'Given Name', with: 'Minnie'
       click_button 'Continue'
       expect(page).to have_selector '#error_explanation'
       expect(page).to have_content "Family name can't be blank"
     end
+
     it 'shows errors when receive_sms_true and local phone is missing' do
+      click_link 'This attendee is not an AGA member'
       fill_in 'Given Name', with: 'Minnie'
       fill_in 'Family Name', with: 'Mouse'
       choose 'registration_gender_f'


### PR DESCRIPTION
Make adding an attendee easier by searching the AGA Members API for
their name or AGA ID and using the values there to pre-fill parts of
their Congress registration.

The new flow presents a starting screen after clicking "add attendee"
that displays only a search box for the API and a button for anyone
trying to register without being a member. (Many non-players and other
guests are attendees at a typical Congress.)

Once either a member is selected via the search or the not-a-member
button is clicked, the next page is the previous registration form, but
with as many values as I could find that were relevant filled in from
existing info.

Closes #192