### PR TITLE
Add new "editable texts" feature for admins

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@ only has autocomplete, datepicker, and dialog. -Jared 2012-07-09 */
 //= require svgxuse.js
 //= require intlTelInput
 //= require libphonenumber/utils
+//= require editable_texts
 
 /* TODO: We only need the galleria stuff on the homepage. Hiding
 this on other pages could improve page speed -Jared 2011.2.3 */
@@ -22,7 +23,7 @@ this on other pages could improve page speed -Jared 2011.2.3 */
 function intlTelFunction() {
   var $phoneInputCollection = $(`[data-intl-phone="true"]`);
 
-  $phoneInputCollection.each(function(i, item) {
+  $phoneInputCollection.each(function (i, item) {
     var $phoneInput = $(item),
       name = $phoneInput.attr("name"),
       hiddenInputName = name,
@@ -39,7 +40,7 @@ function intlTelFunction() {
 
     $phoneInput.intlTelInput({
       initialCountry: "auto",
-      geoIpLookup: function(callback) {
+      geoIpLookup: function (callback) {
         var $this = $(this);
 
         // Try to get IP Info from localStorage, so we don't unnecessarily ping
@@ -47,13 +48,13 @@ function intlTelFunction() {
 
         const ipInfo = localStorage.getItem("countryCodeInfo");
 
-        const handleCountryCode = response => {
+        const handleCountryCode = (response) => {
           const countryCode =
             response && response.country ? response.country : "";
 
           // When we get the country code, loop through all of the phone inputs
           // and see if they have a current value, but not a country code
-          $phoneInputCollection.each(function(i, item) {
+          $phoneInputCollection.each(function (i, item) {
             const $phoneInput = $(item);
 
             const currentNum = $phoneInput
@@ -88,9 +89,9 @@ function intlTelFunction() {
         } else {
           $.get(
             "https://ipinfo.io?token=684cae1e9b5454",
-            function() {},
+            function () {},
             "jsonp"
-          ).always(response => {
+          ).always((response) => {
             localStorage.setItem("countryCodeInfo", JSON.stringify(response));
             handleCountryCode(response);
           });
@@ -99,17 +100,17 @@ function intlTelFunction() {
       hiddenInput: hiddenInputName,
       nationalMode: true,
       formatOnDisplay: true,
-      autoPlaceholder: "polite"
+      autoPlaceholder: "polite",
     });
 
-    var reset = function() {
+    var reset = function () {
       $errorMsg.addClass("hide");
       $validMsg.addClass("hide");
       $phoneInput.removeClass("error-border");
     };
 
     // on blur: validate
-    $phoneInput.blur(function() {
+    $phoneInput.blur(function () {
       reset();
       if ($.trim($phoneInput.val())) {
         if ($phoneInput.intlTelInput("isValidNumber")) {
@@ -138,8 +139,8 @@ function intlTelFunction() {
 $(intlTelFunction);
 
 // check for text areas with a maxlength prop
-$(function() {
-  document.querySelectorAll("textarea[maxlength]").forEach(elem => {
+$(function () {
+  document.querySelectorAll("textarea[maxlength]").forEach((elem) => {
     if (!elem.getAttribute("maxLength")) {
       return;
     }
@@ -148,23 +149,24 @@ $(function() {
     counter.className = "textarea-maxlength-counter";
     elem.parentNode.appendChild(counter);
 
-    elem.addEventListener("keydown", event => {
+    elem.addEventListener("keydown", (event) => {
       updateCounter(elem, counter);
     });
-    elem.addEventListener("keyup", event => {
+    elem.addEventListener("keyup", (event) => {
       updateCounter(elem, counter);
     });
   });
 
   function updateCounter(elem, counter) {
-    counter.innerHTML = `Characters left: ${elem.maxLength -
-      elem.value.length}`;
+    counter.innerHTML = `Characters left: ${
+      elem.maxLength - elem.value.length
+    }`;
   }
 });
 
 // Add a separator control for email lists
-$(function() {
-  document.querySelectorAll("[data-email-list]").forEach(elem => {
+$(function () {
+  document.querySelectorAll("[data-email-list]").forEach((elem) => {
     var separator = document.createElement("div");
     var glueLabel = document.createElement("span");
     var glueInput = document.createElement("input");
@@ -179,17 +181,17 @@ $(function() {
     elem.parentNode.insertBefore(separator, elem);
 
     // Select all on focus
-    glueInput.addEventListener("focus", function(event) {
+    glueInput.addEventListener("focus", function (event) {
       event.target.setSelectionRange(0, this.value.length);
     });
 
     // Update the email list whenever the value changes
-    glueInput.addEventListener("keyup", function(event) {
+    glueInput.addEventListener("keyup", function (event) {
       var char = event.target.value;
       var json = elem.dataset.json;
 
       elem.value = JSON.parse(elem.dataset.json)
-        .map(attendee => `"${attendee.name}" <${attendee.email}>`)
+        .map((attendee) => `"${attendee.name}" <${attendee.email}>`)
         .join(char + " ");
     });
   });
@@ -198,8 +200,8 @@ $(function() {
 /*
  * List Filter
  */
-$(function() {
-  document.querySelectorAll("list-filter").forEach(function(elem) {
+$(function () {
+  document.querySelectorAll("list-filter").forEach(function (elem) {
     var input = document.createElement("input");
     var clear = document.createElement("button");
     clear.innerHTML = "Clear";
@@ -209,18 +211,18 @@ $(function() {
     var list = document.querySelector(elem.dataset.list);
     var items = list.querySelectorAll(elem.dataset.item);
 
-    input.addEventListener("keyup", function(event) {
+    input.addEventListener("keyup", function (event) {
       search(input.value);
     });
 
-    clear.addEventListener("click", function(event) {
+    clear.addEventListener("click", function (event) {
       // TODO: Add keyup trigger
       input.value = "";
       search("");
     });
 
     function search(text) {
-      items.forEach(function(item) {
+      items.forEach(function (item) {
         var value = item.querySelector(elem.dataset.value);
 
         // TODO: Replace with fuzzy search
@@ -239,8 +241,8 @@ $(function() {
  * Adaptive nav
  * @see https://css-tricks.com/container-adapting-tabs-with-more-button/
  */
-$(function() {
-  document.querySelectorAll(".adaptive-nav").forEach(function(container) {
+$(function () {
+  document.querySelectorAll(".adaptive-nav").forEach(function (container) {
     var primary = container.querySelector("ul:first-of-type");
     primary.classList.add("-primary");
     var primaryItems = container.querySelectorAll(
@@ -270,7 +272,7 @@ $(function() {
     var moreLi = primary.querySelector(".-more");
     var moreBtn = moreLi.querySelector("button");
 
-    moreBtn.addEventListener("click", event => {
+    moreBtn.addEventListener("click", (event) => {
       event.preventDefault();
       container.classList.toggle("--show-secondary");
       moreBtn.setAttribute(
@@ -281,7 +283,7 @@ $(function() {
 
     function doAdapt() {
       // reveal all items for the calculation
-      allItems.forEach(function(item) {
+      allItems.forEach(function (item) {
         item.classList.remove("--hidden");
       });
 
@@ -290,7 +292,7 @@ $(function() {
       var hiddenItems = [];
       var primaryWidth = primary.offsetWidth;
 
-      primaryItems.forEach(function(item, i) {
+      primaryItems.forEach(function (item, i) {
         if (primaryWidth >= stopWidth + item.offsetWidth) {
           stopWidth += item.offsetWidth;
         } else {
@@ -305,7 +307,7 @@ $(function() {
         container.classList.remove("--show-secondary");
         moreBtn.setAttribute("aria-expanded", false);
       } else {
-        secondaryItems.forEach(function(item, i) {
+        secondaryItems.forEach(function (item, i) {
           if (!hiddenItems.includes(i)) {
             item.classList.add("--hidden");
           }
@@ -321,7 +323,7 @@ $(function() {
     window.addEventListener("resize", doAdapt);
 
     // hide Secondary on the outside click
-    document.addEventListener("click", function(e) {
+    document.addEventListener("click", function (e) {
       var el = e.target;
       while (el) {
         if (el === secondary || el === moreBtn) {
@@ -335,7 +337,7 @@ $(function() {
   });
 });
 
-$(document).ready(function() {
+$(document).ready(function () {
   if (window.location.search === "?kiosk") {
     displayDailySchedule();
   }
@@ -370,7 +372,7 @@ function displayDailySchedule() {
     var options = {
       hour: "numeric",
       minute: "numeric",
-      hour12: true
+      hour12: true,
     };
     var timeString = now.toLocaleString("en-US", options);
 
@@ -393,7 +395,7 @@ function displayDailySchedule() {
     var scrollAmount = (contentHeight / pages) * currentPage;
     $(viewport).animate(
       {
-        scrollTop: scrollAmount
+        scrollTop: scrollAmount,
       },
       1000
     );
@@ -407,7 +409,7 @@ function displayDailySchedule() {
   function filterPastEvents() {
     var events = schedule.querySelector("tbody").querySelectorAll("tr");
 
-    events.forEach(function(event) {
+    events.forEach(function (event) {
       var $event = $(event);
       var time = event.querySelector(".time").innerHTML.split(" - ");
       var startTime = time[0];

--- a/app/assets/javascripts/editable_texts.js
+++ b/app/assets/javascripts/editable_texts.js
@@ -1,0 +1,40 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const markdownPreviewAreas = document.querySelectorAll(".markdown-preview");
+
+  if (markdownPreviewAreas.length) {
+    markdownPreviewAreas.forEach((elem) => buildPreview(elem));
+  }
+});
+
+const buildPreview = (elem) => {
+  const markdownEditors = elem.querySelectorAll(".markdown");
+
+  markdownEditors.forEach((markdown) => {
+    const preview = document.createElement("div");
+    const previewPanel = document.createElement("div");
+    preview.classList.add("preview");
+    preview.appendChild(previewPanel);
+    previewPanel.classList.add("preview-panel");
+    markdown.after(preview);
+
+    const textarea = markdown.querySelector("textarea");
+    textarea.addEventListener("keyup", (event) => {
+      displayPreview(event.target.value, previewPanel);
+    });
+
+    displayPreview(textarea.value, previewPanel);
+  });
+};
+
+const displayPreview = async (text, elem) => {
+  const response = await fetch("/api/markdown", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ markdown: text }),
+  });
+
+  const { html } = await response.json();
+  elem.innerHTML = html;
+};

--- a/app/assets/stylesheets/editable_texts.scss
+++ b/app/assets/stylesheets/editable_texts.scss
@@ -1,0 +1,78 @@
+// Place all the styles related to the EditableTexts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/
+
+.editable-text {
+  margin-top: 2em;
+
+  h3 {
+    background: transparentize($nav-bg-color, 0.3);
+    padding: 0.5rem 1rem !important;
+    margin-bottom: 0.5rem;
+
+    a {
+      color: #eee;
+      text-decoration: none;
+
+      &:hover {
+        color: $link-color;
+      }
+    }
+  }
+
+  .field {
+    display: flex;
+    margin-bottom: 1rem;
+  }
+
+  .markdown {
+    display: flex;
+    flex-direction: column;
+
+    label {
+      color: #999 !important;
+      display: block !important;
+      padding: 0 0 0 1rem !important;
+      text-transform: uppercase;
+      width: auto !important;
+      text-align: left !important;
+      margin-bottom: 0.5rem;
+    }
+  }
+
+  textarea,
+  .preview-panel {
+    box-sizing: border-box;
+    flex-grow: 1;
+    padding: 1rem;
+  }
+
+  .preview-panel {
+    border: 1px dashed #333;
+    :first-child {
+      margin-top: 0;
+      padding-top: 0;
+    }
+  }
+
+  .preview {
+    position: relative;
+
+    &:before {
+      color: #999;
+      content: "Preview";
+      display: block;
+      font-weight: bold;
+      margin-bottom: 0.5rem;
+      text-transform: uppercase;
+      padding-left: 1rem;
+    }
+
+    margin-left: 1rem;
+  }
+
+  [type="submit"] {
+    margin-left: auto;
+    margin-bottom: 2rem;
+  }
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -12,6 +12,7 @@
 @import "tables";
 @import "jquery_ui_tweaks";
 @import "_shirt_colors";
+@import "editable_texts";
 
 @import "stripe";
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -20,4 +20,10 @@ class ApiController < ApplicationController
 
     render json: result
   end
+
+  # Convert markdown into html
+  def markdown
+    html = helpers.markdown(params['markdown'])
+    render json: { html: html }
+  end
 end

--- a/app/controllers/attendees_controller.rb
+++ b/app/controllers/attendees_controller.rb
@@ -36,14 +36,10 @@ class AttendeesController < ApplicationController
   end
 
   def vip
-    if @year.year != 2019 || current_user_is_admin?
-      @attendees = Attendee
-        .yr(@year)
-        .where(:cancelled => false)
-        .where('rank >= 101')
-        .order('rank desc')
-    else
-      redirect_to year_path
-    end
+    @attendees = Attendee
+      .yr(@year)
+      .where(:cancelled => false)
+      .where('rank >= 101')
+      .order('rank desc')
   end
 end

--- a/app/controllers/editable_texts_controller.rb
+++ b/app/controllers/editable_texts_controller.rb
@@ -1,0 +1,22 @@
+class EditableTextsController < ApplicationController
+  def index
+    @editable_text = EditableText.find_or_create_by(year: @year.year)
+    authorize! :manage, @editable_text
+  end
+
+  def update
+    @editable_text = EditableText.find(params[:id])
+    if @editable_text.update editable_text_params
+      puts editable_text_params
+      redirect_to(editable_texts_path, :notice => 'Editable text updated.')
+    else
+      render :action => "index"
+    end
+  end
+
+  private 
+
+  def editable_text_params
+    params.require(:editable_text).permit(:welcome, :volunteers, :attendees_vip)
+  end
+end

--- a/app/helpers/editable_texts_helper.rb
+++ b/app/helpers/editable_texts_helper.rb
@@ -1,0 +1,9 @@
+module EditableTextsHelper
+  def editable_text name
+    markdown(
+      EditableText
+        .select(name)
+        .find_or_create_by(year: @year.year)[name]
+    ).html_safe
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,7 +5,7 @@ class Ability
   # when the cancan syntax does not allow the symbol :all
   # For example, when applying conditions, eg. :year
   ALL_RESOURCES = [Activity, ActivityCategory, Attendee,
-    Contact, Content, ContentCategory, Event, GameAppointment,
+    Contact, Content, ContentCategory, EditableText, Event, GameAppointment,
     PlanCategory, Plan, Round, Shirt, SmsNotification, Transaction, Tournament,
     User, Year]
 

--- a/app/models/editable_text.rb
+++ b/app/models/editable_text.rb
@@ -1,0 +1,18 @@
+class EditableText < ApplicationRecord
+  include YearlyModel
+  after_initialize :init
+
+  def init
+    if self.has_attribute? :attendees_vip
+      self.attendees_vip ||= "Professional Go teachers will attend the 2021 U.S. Go Congress. As the list of attending Pros is created, descriptions of them will appear on this webpage."
+    end
+
+    if self.has_attribute? :volunteers
+      self.volunteers ||= "From **tournament directors** to the people who volunteer **only a few hours at the front desk**, we need your help.  The Go Congress would not be possible without the dedication of dozens of volunteers.  Please email the congress directors to volunteer at this year’s congress. Thanks!"
+    end
+
+    if self.has_attribute? :welcome
+      self.welcome ||= "The U.S. Go Congress is the largest go activity in the United States. It happens once a year and spans one week. Events include the U.S. Open, the largest annual go tournament in the U.S., professional lectures and game analysis, continuous self-paired games, and all kinds of go-related activities from morning to midnight. Come for the go. Come for the camaraderie of old friends. Whatever your reason, we are looking forward to seeing you there."
+    end
+  end
+end

--- a/app/views/attendees/vip.html.haml
+++ b/app/views/attendees/vip.html.haml
@@ -1,8 +1,6 @@
 %h2 Professionals
 
-%p
-  Professional Go teachers will attend the #{@year} U.S. Go Congress. As the list of
-  attending Pros is created, descriptions of them will appear on this webpage.
+= editable_text('attendees_vip')
 
 - if @attendees.size > 0
   %h3= pluralize(@attendees.size, 'Registered Pro')

--- a/app/views/contacts/index.html.haml
+++ b/app/views/contacts/index.html.haml
@@ -1,10 +1,5 @@
 %h2 Volunteers
-:markdown
-  From **tournament directors** to the people who volunteer
-  **only a few hours at the front desk**, we need your help.
-  The Go Congress would not be possible without the
-  dedication of dozens of volunteers.  Please email the congress
-  directors to volunteer at this year’s congress.  Thanks!
+= editable_text('volunteers')
 
 %h2 Contact Us
 

--- a/app/views/content_categories/index.html.haml
+++ b/app/views/content_categories/index.html.haml
@@ -1,4 +1,12 @@
+- if can? :manage, EditableText
+  %h2 Editable Text
+  %ul
+    %li
+      = link_to "View and edit website text", editable_texts_path  
+
 %h2 Content Categories
+
+
 
 - if can? :create, ContentCategory
   .flow-padding= button_to 'New Category', new_content_category_path, :method => "get"

--- a/app/views/editable_texts/index.html.haml
+++ b/app/views/editable_texts/index.html.haml
@@ -1,0 +1,32 @@
+%h2 Editable Text
+
+%p Many sections of website text can be customized; in fact, it&rsquo;s encouraged. It shows that your year&rsquo;s Congress is unique. All text uses #{link_to "Markdown", "https://daringfireball.net/projects/markdown/"}.
+
+%fieldset.markdown-preview.editable-text
+  = form_for @editable_text do |f|
+    %h3
+      = link_to "Welcome", root_path
+    .field
+      %div.markdown
+        = f.label :welcome, "Markdown"
+        = f.text_area :welcome
+    = f.submit 'Save'
+
+  = form_for @editable_text do |f|
+    %h3
+      = link_to "Professionals", attendees_path + '/vip'
+    .field
+      %div.markdown
+        = f.label :attendees_vip, "Markdown"
+        = f.text_area :attendees_vip
+    = f.submit 'Save'
+
+  = form_for @editable_text do |f|
+    %h3
+      = link_to "Volunteers", :contacts
+    .field
+      %div.markdown
+        = f.label :volunteers, "Markdown"
+        = f.text_area :volunteers
+
+    = f.submit 'Save'

--- a/app/views/home/_logo_and_welcome.haml
+++ b/app/views/home/_logo_and_welcome.haml
@@ -21,38 +21,4 @@
       The #{@year.ordinal_number.ordinalize}&nbsp;Annual
       U.S.&nbsp;Go&nbsp;Congress
 
-  %p
-    - if @year.year >= 2016
-      The U.S. Go Congress is the largest go activity in the United States. It
-      happens once a year and spans one week. Events include the U.S. Open, the
-      largest annual go tournament in the U.S., professional lectures and game
-      analysis, continuous self-paired games, and all kinds of go-related
-      activities from morning to midnight. Come for the go. Come for the
-      camaraderie of old friends. Whatever your reason, we are looking forward
-      to seeing you there.
-    - elsif @year.year == 2015
-      The Twin Cities Go Club invites you to join us at the 2015 U.S. Go
-      Congress. The U.S. Go Congress is the largest go activity in the United
-      States. It happens once a year and spans one week. Events include the U.S.
-      Open, the largest annual go tournament in the U.S., professional lectures
-      and game analysis, continuous self-paired games, and all kinds of
-      go-related activities from morning to midnight. We believe there is
-      something for everybody in the Twin Cities where urban settings meet the
-      natural beauty of Minnesota's 10,000 lakes and the Mississippi River. We
-      look forward to seeing you in Saint Paul!
-    - elsif @year.year == 2014
-      The U.S. Go Congress is the largest go activity in the United States. It
-      happens once a year and spans one week. Events include the U.S. Open, the
-      largest annual go tournament in the U.S., professional lectures and game
-      analysis, continuous self-paired games, and all kinds of go-related
-      activities from morning to midnight. Come for the go, come for the
-      camaraderie of old friends, come for the thrill of the big city! Whatever
-      your reason, we are looking forward to seeing you there.
-    - else
-      The U.S. Go Congress is the largest Go activity in the United States. It
-      happens once a year and spans one week. Events include the U.S. Open, the
-      largest annual Go tournament in the U.S., professional lectures and game
-      analysis, continuous self paired games, and all kinds of Go related
-      activities from morning to midnight. Come for the Go, come for the
-      camaraderie of old friends, come for the relaxing mountain air. Whatever
-      your reason, we are looking forward to seeing you there.
+  = editable_text('welcome')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Gocongress::Application.routes.draw do
 
   # proxy
   get 'api/mm/members/:search', to: 'api#search_members'
+  post 'api/markdown', to: 'api#markdown'
 
 
   # Put the root route at the top so that it is matched quickly
@@ -100,6 +101,8 @@ Gocongress::Application.routes.draw do
               :user_invoices
           end
         end
+
+        resources :editable_texts
 
         # Check attendees in to Congress when they arrive
         get 'check-in', to: 'check_in#index'

--- a/db/migrate/20210506021835_create_editable_texts.rb
+++ b/db/migrate/20210506021835_create_editable_texts.rb
@@ -1,0 +1,12 @@
+class CreateEditableTexts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :editable_texts do |t|
+      t.integer :year
+      t.string  :welcome
+      t.string  :volunteers
+      t.string  :attendees_vip
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210426141815) do
+ActiveRecord::Schema.define(version: 20210506021835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "activities", force: :cascade do |t|
+  create_table "activities", id: :bigserial, force: :cascade do |t|
     t.string   "name",                 limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -35,14 +35,14 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["year", "leave_time"], name: "index_activities_on_year_and_start", using: :btree
   end
 
-  create_table "activity_categories", force: :cascade do |t|
+  create_table "activity_categories", id: :bigserial, force: :cascade do |t|
     t.string  "name",        limit: 25,  null: false
     t.integer "year",                    null: false
     t.string  "description", limit: 500
     t.index ["id", "year"], name: "uniq_activity_categories_on_id_and_year", unique: true, using: :btree
   end
 
-  create_table "attendee_activities", force: :cascade do |t|
+  create_table "attendee_activities", id: :bigserial, force: :cascade do |t|
     t.integer  "attendee_id", null: false
     t.integer  "activity_id", null: false
     t.datetime "created_at"
@@ -52,12 +52,12 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["attendee_id", "activity_id"], name: "uniq_attendee_activity", unique: true, using: :btree
   end
 
-  create_table "attendee_plan_dates", force: :cascade do |t|
+  create_table "attendee_plan_dates", id: :bigserial, force: :cascade do |t|
     t.date    "_date",            null: false
     t.integer "attendee_plan_id"
   end
 
-  create_table "attendee_plans", force: :cascade do |t|
+  create_table "attendee_plans", id: :bigserial, force: :cascade do |t|
     t.integer  "attendee_id",             null: false
     t.integer  "plan_id",                 null: false
     t.datetime "created_at"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["attendee_id", "plan_id"], name: "uniq_attendee_plan", unique: true, using: :btree
   end
 
-  create_table "attendees", force: :cascade do |t|
+  create_table "attendees", id: :bigserial, force: :cascade do |t|
     t.string   "given_name",               limit: 255,                 null: false
     t.string   "family_name",              limit: 255,                 null: false
     t.string   "gender",                   limit: 1
@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["user_id"], name: "index_attendees_on_user_id", using: :btree
   end
 
-  create_table "bye_appointments", force: :cascade do |t|
+  create_table "bye_appointments", id: :bigserial, force: :cascade do |t|
     t.integer  "round_id"
     t.integer  "attendee_id"
     t.datetime "created_at",  null: false
@@ -116,7 +116,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["round_id"], name: "index_bye_appointments_on_round_id", using: :btree
   end
 
-  create_table "contacts", force: :cascade do |t|
+  create_table "contacts", id: :bigserial, force: :cascade do |t|
     t.integer  "year",                    null: false
     t.string   "title",       limit: 50,  null: false
     t.string   "given_name",  limit: 50,  null: false
@@ -128,7 +128,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.datetime "updated_at",              null: false
   end
 
-  create_table "content_categories", force: :cascade do |t|
+  create_table "content_categories", id: :bigserial, force: :cascade do |t|
     t.integer  "year",                                         null: false
     t.string   "name",              limit: 50
     t.datetime "created_at"
@@ -137,7 +137,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["id", "year"], name: "index_content_categories_on_id_and_year", unique: true, using: :btree
   end
 
-  create_table "contents", force: :cascade do |t|
+  create_table "contents", id: :bigserial, force: :cascade do |t|
     t.text     "body",                            null: false
     t.string   "subject",             limit: 255, null: false
     t.datetime "expires_at"
@@ -150,13 +150,22 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["year", "show_on_homepage", "expires_at"], name: "index_contents_on_year_and_show_on_homepage_and_expires_at", using: :btree
   end
 
-  create_table "events", force: :cascade do |t|
+  create_table "editable_texts", force: :cascade do |t|
+    t.integer  "year"
+    t.string   "welcome"
+    t.string   "volunteers"
+    t.string   "attendees_vip"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  create_table "events", id: :bigserial, force: :cascade do |t|
     t.integer "year",             null: false
     t.string  "name", limit: 255, null: false
     t.index ["id", "year"], name: "index_events_on_id_and_year", unique: true, using: :btree
   end
 
-  create_table "game_appointments", force: :cascade do |t|
+  create_table "game_appointments", id: :bigserial, force: :cascade do |t|
     t.string   "location"
     t.datetime "time"
     t.datetime "created_at",      null: false
@@ -174,13 +183,13 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["round_id"], name: "index_game_appointments_on_round_id", using: :btree
   end
 
-  create_table "jobs", force: :cascade do |t|
+  create_table "jobs", id: :bigserial, force: :cascade do |t|
     t.string   "jobname"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "plan_categories", force: :cascade do |t|
+  create_table "plan_categories", id: :bigserial, force: :cascade do |t|
     t.string   "name",                 limit: 255,                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -195,7 +204,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["id", "year"], name: "index_plan_categories_on_id_and_year", unique: true, using: :btree
   end
 
-  create_table "plans", force: :cascade do |t|
+  create_table "plans", id: :bigserial, force: :cascade do |t|
     t.string   "name",                 limit: 50,                 null: false
     t.integer  "age_min",                                         null: false
     t.integer  "age_max"
@@ -217,7 +226,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["plan_category_id"], name: "index_plans_on_plan_category_id", using: :btree
   end
 
-  create_table "rounds", force: :cascade do |t|
+  create_table "rounds", id: :bigserial, force: :cascade do |t|
     t.integer  "tournament_id"
     t.integer  "number"
     t.datetime "start_time",           null: false
@@ -228,7 +237,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["tournament_id"], name: "index_rounds_on_tournament_id", using: :btree
   end
 
-  create_table "shirts", force: :cascade do |t|
+  create_table "shirts", id: :bigserial, force: :cascade do |t|
     t.integer  "year",                                    null: false
     t.string   "name",        limit: 40,                  null: false
     t.string   "hex_triplet", limit: 6,                   null: false
@@ -242,7 +251,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["name", "year"], name: "index_shirts_on_name_and_year", unique: true, using: :btree
   end
 
-  create_table "sms_notifications", force: :cascade do |t|
+  create_table "sms_notifications", id: :bigserial, force: :cascade do |t|
     t.string   "to"
     t.string   "from"
     t.text     "message"
@@ -250,7 +259,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "tournaments", force: :cascade do |t|
+  create_table "tournaments", id: :bigserial, force: :cascade do |t|
     t.string   "name",             limit: 50,                  null: false
     t.string   "eligible",         limit: 255,                 null: false
     t.text     "description",                                  null: false
@@ -265,7 +274,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["id", "year"], name: "index_tournaments_on_id_and_year", unique: true, using: :btree
   end
 
-  create_table "transactions", force: :cascade do |t|
+  create_table "transactions", id: :bigserial, force: :cascade do |t|
     t.integer  "user_id",                        null: false
     t.string   "trantype",           limit: 1,   null: false
     t.string   "gwtranid"
@@ -283,7 +292,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["year", "created_at"], name: "index_transactions_on_year_and_created_at", using: :btree
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :bigserial, force: :cascade do |t|
     t.string   "email",                  limit: 255, default: "",  null: false
     t.string   "encrypted_password",     limit: 128, default: "",  null: false
     t.string   "reset_password_token",   limit: 255
@@ -304,7 +313,7 @@ ActiveRecord::Schema.define(version: 20210426141815) do
     t.index ["year"], name: "index_users_on_year", using: :btree
   end
 
-  create_table "years", force: :cascade do |t|
+  create_table "years", id: :bigserial, force: :cascade do |t|
     t.string  "city",               limit: 255
     t.string  "date_range",         limit: 255,             null: false
     t.date    "day_off_date",                               null: false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include FactoryBot::Syntax::Methods
 end
 

--- a/spec/requests/editable_texts_spec.rb
+++ b/spec/requests/editable_texts_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+year = Date.today.year
+
+RSpec.describe "EditableTexts", type: :request do
+  context "as a user" do
+    let(:user) { create :user}
+    before { sign_in user}
+
+    describe "GET editable_texts/" do
+      it "is forbidden" do
+        get "/#{year}/editable_texts/", :params => {}
+        expect(response).to be_forbidden
+      end
+    end
+  end
+
+  context "as staff" do
+    let(:staff) { create :staff }
+    before { sign_in staff }
+
+    describe "GET editable_texts/" do
+      it "is forbidden" do
+        get "/#{year}/editable_texts/", :params => {}
+        expect(response).to be_forbidden
+      end
+    end
+  end
+
+  context "as an admin" do
+    let(:admin) { create :admin }
+    before { sign_in admin }
+
+    describe "GET editable_texts/" do
+      it "returns http success" do
+        get "/#{year}/editable_texts/", :params => {}
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This new feature lets admins update the text for visible sections of the
website without needing to modify code in the site itself. It creates a
new admin section accessible via "Content" that lets admins write
content in Markdown that will be displayed in major sections of the
site, such as the logo and welcome on the homepage, the contact us page,
and the pros page.

We'll probably add other sections to this later on. We could also add
some easier ways for admins to directly edit text *from* where they
actually live rather than having to go to a specific admin page, but we
can add those later.

Closes #191 