### PR TITLE
De-skip the pandanet tests

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -34,19 +34,10 @@ class ApiController < ApplicationController
   def pandanet_username
     username = params.fetch('username')
     stats = Pandanet::Client.new.stats(username)
-    if stats.start_with?("Cannot find player.")
+    if stats.nil?
       render json: '{"error": "not_found"}', status: :not_found
     else
-      rating = stats.match(/Rating:\s*([1-9][0-9]?[dk])/)[1]
-      rank = stats.match(/Rank:\s*([1-9][0-9]?[dk])/)[1]
-      country = stats.match(/Country:\s*([A-Za-z]+)/)[1]
-      player_information = {
-        :username => username,
-        :rating => rating,
-        :rank => rank,
-        :country => country
-      }
-      render json: player_information
+      render json: stats.to_h
     end
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -32,28 +32,22 @@ class ApiController < ApplicationController
 
   # Use telnet to access Pandanet to get member information
   def pandanet_username
-    server = Net::Telnet.new("Host" => "igs.joyjoy.net", "Port" => 7777, "Timeout" => 10, "Prompt" => /#> /)
-    server.login(ENV['PANDANET_USERNAME'], ENV['PANDANET_PASSWORD'])
-
-    server.cmd("stats #{params['username']}") do |result|
-      if result.start_with?("Cannot find player.")
-        render json: '{"error": "not_found"}', status: :not_found
-      else
-        rating = result.match(/Rating:\s*([1-9][0-9]?[dk])/)[1]
-        rank = result.match(/Rank:\s*([1-9][0-9]?[dk])/)[1]
-        country = result.match(/Country:\s*([A-Za-z]+)/)[1]
-        player_information = {
-          :username => params['username'],
-          :rating => rating,
-          :rank => rank,
-          :country => country
-        }
-        render json: player_information
-      end
+    username = params.fetch('username')
+    stats = Pandanet::Client.new.stats(username)
+    if stats.start_with?("Cannot find player.")
+      render json: '{"error": "not_found"}', status: :not_found
+    else
+      rating = stats.match(/Rating:\s*([1-9][0-9]?[dk])/)[1]
+      rank = stats.match(/Rank:\s*([1-9][0-9]?[dk])/)[1]
+      country = stats.match(/Country:\s*([A-Za-z]+)/)[1]
+      player_information = {
+        :username => username,
+        :rating => rating,
+        :rank => rank,
+        :country => country
+      }
+      render json: player_information
     end
-
-    server.cmd("quit")
-    server.close
   end
 
   # Use KGS's archives page to see if a username exists

--- a/app/services/pandanet/client.rb
+++ b/app/services/pandanet/client.rb
@@ -45,6 +45,8 @@ module Pandanet
     # Info:  <None>
     # Defaults (help defs):  time 90, size 19, byo-yomi time 10, byo-yomi stones 25
     # ```
+    #
+    # @return [nil | Stats]
     def stats(username)
       # Debugging tip: add the "Output_log" option.
       server = Net::Telnet.new(
@@ -65,7 +67,7 @@ module Pandanet
       server.cmd("quit")
       server.close
 
-      stats_result
+      Stats.parse(username, stats_result)
     end
   end
 end

--- a/app/services/pandanet/client.rb
+++ b/app/services/pandanet/client.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Pandanet
+  # We connect to Pandanet to get information about an `Attendee`. We connect
+  # with telnet.
+  #
+  # ## Timeout during `login`
+  #
+  # If `PANDANET_USERNAME` has been used by a "client application", such
+  # as `glGo`, the telent server will remember, and will use numeric codes
+  # instead of speaking "English". So, for example, it'll print "1 1" and
+  # we'll wait for it to print "Login: ". This is described in the docs
+  # (http://www.pandanet.co.jp/English/sintro1.html)
+  #
+  # > If you use a client, your client will set your login to 'client mode',
+  # > and should you later telnet to IGS without it, you may find that your
+  # > familiar prompt has changed and looks like:
+  # >
+  # >   1 1  or  1 5
+  # >
+  # > Don't panic if you don't see your familiar prompt, just complete your
+  # > login by entering your account name and password. After you enter IGS,
+  # > enter toggle client.
+  #
+  # So, that's one way that "client mode" can be fixed manually. There may
+  # be a more automatic way, perhaps when establishing the initial connection?
+  class Client
+    # Returns a String like:
+    #
+    # ```
+    # Player:      cloudbrows
+    # Game:        go (1)
+    # Language:    default
+    # Rating:      1d    0
+    # Rated Games:      0
+    # Rank:  1d  29
+    # Wins:         0
+    # Losses:       0
+    # Last Access(GMT):   (Not on)    Sat May 29 13:56:48 2021
+    # Last Access(local): (Not on)    Sat May 29 22:56:48 2021
+    # Address:  panda@.us
+    # Country:  USA
+    # Community:  -
+    # Reg date: Mon Jan  1 00:00:00 1900
+    # Info:  <None>
+    # Defaults (help defs):  time 90, size 19, byo-yomi time 10, byo-yomi stones 25
+    # ```
+    def stats(username)
+      # Debugging tip: add the "Output_log" option.
+      server = Net::Telnet.new(
+        "Host" => "igs.joyjoy.net",
+        "Port" => 7777,
+        "Timeout" => 10,
+        "Prompt" => /#> /
+      )
+
+      # If a timeout occurs during `login`, see notes above.
+      server.login(ENV['PANDANET_USERNAME'], ENV['PANDANET_PASSWORD'])
+
+      stats_result = nil
+      server.cmd("stats #{username}") do |result|
+        stats_result = result
+      end
+
+      server.cmd("quit")
+      server.close
+
+      stats_result
+    end
+  end
+end

--- a/app/services/pandanet/stats.rb
+++ b/app/services/pandanet/stats.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Pandanet
+  # Data object representing information about a Pandanet username.
+  class Stats
+    def initialize(username, rating, rank, country)
+      @username = username
+      @rating = rating
+      @rank = rank
+      @country = country
+    end
+
+    class << self
+      # Parse the response received from the telnet `stats` command.
+      def parse(username, str)
+        return nil if str.start_with?("Cannot find player.")
+        rating = str.match(/Rating:\s*([1-9][0-9]?[dk])/)[1]
+        rank = str.match(/Rank:\s*([1-9][0-9]?[dk])/)[1]
+        country = str.match(/Country:\s*([A-Za-z]+)/)[1]
+        new(username, rating, rank, country)
+      end
+    end
+
+    def to_h
+      {
+        username: @username,
+        rating: @rating,
+        rank: @rank,
+        country: @country
+      }
+    end
+  end
+end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -38,37 +38,21 @@ RSpec.describe "API", type: :request do
       it "returns member info for a username that exists" do
         mock_client = instance_double(::Pandanet::Client)
         allow(::Pandanet::Client).to receive(:new).and_return(mock_client)
-        mock_stats = <<~EOS
-          Player:      cloudbrows
-          Game:        go (1)
-          Language:    default
-          Rating:      1d    0
-          Rated Games:      0
-          Rank:  1d  29
-          Wins:         0
-          Losses:       0
-          Last Access(GMT):   (Not on)    Sat May 29 13:56:48 2021
-          Last Access(local): (Not on)    Sat May 29 22:56:48 2021
-          Address:  panda@.us
-          Country:  USA
-          Community:  -
-          Reg date: Mon Jan  1 00:00:00 1900
-          Info:  <None>
-          Defaults (help defs):  time 90, size 19, byo-yomi time 10, byo-yomi stones 25
-        EOS
-        allow(mock_client).to(receive(:stats).and_return(mock_stats))
+        allow(mock_client).to receive(:stats).and_return(
+          ::Pandanet::Stats.new('cloudbrows', '1d', '1d', 'USA')
+        )
 
         get "/api/pandanet/cloudbrows", :params => {}
         parsed_body = JSON.parse(response.body)
 
         expect(parsed_body["rating"]).to eq('1d')
+        expect(parsed_body["country"]).to eq('USA')
       end
 
       it "returns an error for a username that doesn't exist" do
         mock_client = instance_double(::Pandanet::Client)
         allow(::Pandanet::Client).to receive(:new).and_return(mock_client)
-        mock_stats = 'Cannot find player.'
-        allow(mock_client).to(receive(:stats).and_return(mock_stats))
+        allow(mock_client).to(receive(:stats).and_return(nil))
 
         get "/api/pandanet/nosanepersonchoosethisname", :params => {}
         parsed_body = JSON.parse(response.body)

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe "API", type: :request do
@@ -34,17 +36,39 @@ RSpec.describe "API", type: :request do
 
     describe "GET Pandanet Username" do
       it "returns member info for a username that exists" do
-        skip 'Test fails with Net::ReadTimeout. Temporarily skip until a solution is found'
+        mock_client = instance_double(::Pandanet::Client)
+        allow(::Pandanet::Client).to receive(:new).and_return(mock_client)
+        mock_stats = <<~EOS
+          Player:      cloudbrows
+          Game:        go (1)
+          Language:    default
+          Rating:      1d    0
+          Rated Games:      0
+          Rank:  1d  29
+          Wins:         0
+          Losses:       0
+          Last Access(GMT):   (Not on)    Sat May 29 13:56:48 2021
+          Last Access(local): (Not on)    Sat May 29 22:56:48 2021
+          Address:  panda@.us
+          Country:  USA
+          Community:  -
+          Reg date: Mon Jan  1 00:00:00 1900
+          Info:  <None>
+          Defaults (help defs):  time 90, size 19, byo-yomi time 10, byo-yomi stones 25
+        EOS
+        allow(mock_client).to(receive(:stats).and_return(mock_stats))
 
         get "/api/pandanet/cloudbrows", :params => {}
         parsed_body = JSON.parse(response.body)
 
-        expect(parsed_body["rating"]).to be_a(String)
-        expect(parsed_body["rating"]).not_to be_falsey
+        expect(parsed_body["rating"]).to eq('1d')
       end
 
       it "returns an error for a username that doesn't exist" do
-        skip 'Test fails with Net::ReadTimeout. Temporarily skip until a solution is found'
+        mock_client = instance_double(::Pandanet::Client)
+        allow(::Pandanet::Client).to receive(:new).and_return(mock_client)
+        mock_stats = 'Cannot find player.'
+        allow(mock_client).to(receive(:stats).and_return(mock_stats))
 
         get "/api/pandanet/nosanepersonchoosethisname", :params => {}
         parsed_body = JSON.parse(response.body)

--- a/spec/services/pandanet/stats_spec.rb
+++ b/spec/services/pandanet/stats_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Pandanet
+  RSpec.describe Stats do
+    describe '.parse' do
+      it 'parses the response received from the telnet `stats` command' do
+        response = <<~EOS
+          Player:      cloudbrows
+          Game:        go (1)
+          Language:    default
+          Rating:      1d    0
+          Rated Games:      0
+          Rank:  1d  29
+          Wins:         0
+          Losses:       0
+          Last Access(GMT):   (Not on)    Sat May 29 13:56:48 2021
+          Last Access(local): (Not on)    Sat May 29 22:56:48 2021
+          Address:  panda@.us
+          Country:  USA
+          Community:  -
+          Reg date: Mon Jan  1 00:00:00 1900
+          Info:  <None>
+          Defaults (help defs):  time 90, size 19, byo-yomi time 10, byo-yomi stones 25
+        EOS
+        stats = described_class.parse('cloudbrows', response).to_h
+        expect(stats[:username]).to eq('cloudbrows')
+        expect(stats[:rating]).to eq('1d')
+        expect(stats[:rank]).to eq('1d')
+        expect(stats[:country]).to eq('USA')
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are a few things to talk about here.

The goal is to test the Pandanet `stats` feature, without an actual (fallible) network connection. Extracting a `::Pandanet::Client` class gives the controller something to mock. This is the more important commit. Then, extracting the `Stats` class enables us to test the parsing.

I ran into an issue re: Pandanet "client mode", which I documented in `services/pandanet/client.rb`.

Finally, I noticed that staging has a `PANDANET_USERNAME` set, but production does not.