### PR TITLE
Add ordinal and URL to content categories

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
     @congress_date_range = @year.date_range
 
     # The layout needs a list of content and activity categories
-    @content_categories_for_menu = ContentCategory.yr(@year).order(:name)
+    @content_categories_for_menu = ContentCategory.yr(@year).order(:ordinal, :name)
     @activity_categories_for_menu = ActivityCategory.yr(@year).order(:name)
     @tournaments_for_nav_menu = Tournament.yr(@year).nav_menu
   end

--- a/app/controllers/content_categories_controller.rb
+++ b/app/controllers/content_categories_controller.rb
@@ -47,6 +47,6 @@ protected
   private
 
   def content_category_params
-    params.require(:content_category).permit(:name, :table_of_contents)
+    params.require(:content_category).permit(:name, :table_of_contents, :ordinal, :url)
   end
 end

--- a/app/views/content_categories/_form.html.haml
+++ b/app/views/content_categories/_form.html.haml
@@ -1,13 +1,33 @@
 = form_for @content_category do |f|
   = render :partial => "shared/error_messages", :locals => { :resource => @content_category }
 
-  .field
-    = f.label :name
-    = f.text_field :name, tab_index: 1
+  .field.flex
+    %div.field-key
+      = f.label :name
+    %div.field-value
+      = f.text_field :name
 
-  .field
-    = f.label :table_of_contents
-    = f.check_box :table_of_contents, tab_index: 2
+  .field.flex
+    %div.field-key
+      = f.label :table_of_contents
+    %div.field-value
+      = f.check_box :table_of_contents
+
+  .field.flex
+    %div.field-key
+      = f.label :ordinal
+    %div.field-value
+      = f.text_field :ordinal
+      %div.field-help-text
+        You may set an ordinal value to explicitly order content items in the navigation bar.
+
+  .field.flex
+    %div.field-key
+      = f.label :url
+    %div.field-value
+      = f.text_field :url, { :placeholder => "http://www.someurl.com"}
+      %div.field-help-text
+        If a URL is present, this content category will exist only as a link in the header. It will display no other content.
 
   .field
     %label

--- a/app/views/layouts/_nav.haml
+++ b/app/views/layouts/_nav.haml
@@ -29,7 +29,10 @@
       - if @year.year != 2019 || current_user_is_admin?
         %li= link_to "Costs", costs_path
       - @content_categories_for_menu.each do |c|
-        %li= link_to c.name, c
+        - if c.url
+          %li= link_to c.name, c.url
+        - else
+          %li= link_to c.name, c
       - if @year.year == 2016
         %li= link_to "Schedule", "http://live.gocongress.org/"
       %li= link_to "Contact / Volunteer", contacts_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
         show_on_homepage: "Show on Homepage?"
       content_category:
         name: "Category"
+        url: "URL"
       plan:
         age_min: "Minimum Age"
         age_max: "Maximum Age"

--- a/db/migrate/20210616023945_add_ordinal_and_url_to_content_categories.rb
+++ b/db/migrate/20210616023945_add_ordinal_and_url_to_content_categories.rb
@@ -1,0 +1,6 @@
+class AddOrdinalAndUrlToContentCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :content_categories, :ordinal, :integer, null: false, default: 1
+    add_column :content_categories, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_26_231226) do
+ActiveRecord::Schema.define(version: 2021_06_16_023945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,8 @@ ActiveRecord::Schema.define(version: 2021_05_26_231226) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "table_of_contents", default: false
+    t.integer "ordinal", default: 1, null: false
+    t.string "url"
     t.index ["id", "year"], name: "index_content_categories_on_id_and_year", unique: true
   end
 


### PR DESCRIPTION
* Ordinal allows content categories to be explicitly ordered by an
  admin, rather than just alphabetically by name

* URL allows content category to act as an external link in the nav bar

Closes #214 