### PR TITLE
Add ordinal to contents

### DIFF
--- a/app/assets/stylesheets/editable_texts.scss
+++ b/app/assets/stylesheets/editable_texts.scss
@@ -35,6 +35,7 @@
     flex-direction: column;
 
     label {
+      font-weight: bold;
       color: #999 !important;
       display: block !important;
       padding: 0 0 0 1rem !important;
@@ -68,7 +69,7 @@
       content: "Preview";
       display: block;
       font-weight: bold;
-      margin-bottom: 0.5rem;
+      margin: 0 0 0.5rem;
       text-transform: uppercase;
       padding-left: 1rem;
     }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1087,3 +1087,18 @@ select {
     opacity: 1;
   }
 }
+
+.preview {
+  position: relative;
+
+  &:before {
+    color: #999;
+    content: "Preview";
+    display: block;
+    font-weight: bold;
+    margin: 1rem 0 0.5rem;
+    text-transform: uppercase;
+  }
+
+  margin-left: 1rem;
+}

--- a/app/controllers/content_categories_controller.rb
+++ b/app/controllers/content_categories_controller.rb
@@ -27,7 +27,7 @@ class ContentCategoriesController < ApplicationController
   end
 
   def show
-    @contents = @content_category.contents_chronological
+    @contents = @content_category.contents_ordinal
   end
 
   def update

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -51,7 +51,7 @@ class ContentsController < ApplicationController
   private
 
   def content_params
-    params.require(:content).permit(:body, :content_category_id, :expires_at,
+    params.require(:content).permit(:body, :content_category_id, :ordinal, :expires_at,
       :show_on_homepage, :subject)
   end
 end

--- a/app/models/content_category.rb
+++ b/app/models/content_category.rb
@@ -6,4 +6,8 @@ class ContentCategory < ApplicationRecord
   def contents_chronological
     contents.order('created_at desc')
   end
+
+  def contents_ordinal
+    contents.order('ordinal, subject')
+  end
 end

--- a/app/views/contents/_form.html.haml
+++ b/app/views/contents/_form.html.haml
@@ -1,20 +1,39 @@
 = form_for @content do |f|
   = render :partial => "shared/error_messages", :locals => { :resource => @content }
 
-  .field
-    = f.label :subject
-    = f.text_field :subject
-  .field
-    = f.label :content_category_id
-    = f.select :content_category_id, content_category_options, :selected => @selected_category_id
-  .field
+  .field.flex
+    %div.field-key
+      = f.label :subject
+    %div.field-value
+      = f.text_field :subject
+
+  .field.flex
+    %div.field-key
+      = f.label :content_category_id
+    %div.field-value
+      = f.select :content_category_id, content_category_options, :selected => @selected_category_id
+
+  .field.flex 
+    %div.field-key
+      = f.label :ordinal
+    %div.field-value
+      = f.number_field :ordinal
+      %div.field-help-text You can explicitly control the order of this content within its content category's list, if needed.
+
+  .field.flex
     = render partial: "shared/md_area", locals: { :obj => :content, :atr => :body, :rows => 20 }
-  .field
-    = f.label :expires_at
-    = f.datetime_select :expires_at, :include_blank => true
-  .field
-    = f.label :show_on_homepage
-    = f.check_box :show_on_homepage
+
+  .field.flex
+    %div.field-key
+      = f.label :expires_at
+    %div.field-value
+      = f.datetime_select :expires_at, :include_blank => true
+
+  .field.flex
+    %div.field-key
+      = f.label :show_on_homepage
+    %div.field-value
+      = f.check_box :show_on_homepage
 
   .field
     %label

--- a/app/views/shared/_md_area.html.haml
+++ b/app/views/shared/_md_area.html.haml
@@ -1,7 +1,7 @@
-/ Parameters:
-/ obj - a symbol naming an activerecord model
-/ atr - a symbol naming an attribute of said model
-/ rows - number of rows for textarea
+-# / Parameters:
+-# / obj - a symbol naming an activerecord model
+-# / atr - a symbol naming an attribute of said model
+-# / rows - number of rows for textarea
 
 - rows ||= 5
 
@@ -13,5 +13,7 @@
       You can format the text (bold, etc.) with
       %a{ :href => 'https://daringfireball.net/projects/markdown/syntax', :target => '_blank' } Markdown.
 
-%div.field-value
-  = text_area obj, atr, { maxlength: defined?(maximum_length) ? maximum_length : "", :class => 'wide', :rows => rows }
+.field-value
+  .markdown-preview
+    .markdown
+      = text_area obj, atr, { maxlength: defined?(maximum_length) ? maximum_length : "", :class => 'wide', :rows => rows }

--- a/db/migrate/20210616193834_add_ordinal_to_contents.rb
+++ b/db/migrate/20210616193834_add_ordinal_to_contents.rb
@@ -1,0 +1,5 @@
+class AddOrdinalToContents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :contents, :ordinal, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_16_023945) do
+ActiveRecord::Schema.define(version: 2021_06_16_193834) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(version: 2021_06_16_023945) do
     t.datetime "updated_at"
     t.integer "year", null: false
     t.integer "content_category_id", null: false
+    t.integer "ordinal", default: 1, null: false
     t.index ["content_category_id"], name: "index_contents_on_content_category_id"
     t.index ["year", "show_on_homepage", "expires_at"], name: "index_contents_on_year_and_show_on_homepage_and_expires_at"
   end


### PR DESCRIPTION
Allow contents to be ordered within their content category by setting an
ordinal on the individual items.

Also adds a general markdown preview capability to most common markdown
fields to make it easier for admins to see what their markdown will look
like.

![2021-06-16 at 4 11 PM](https://user-images.githubusercontent.com/176993/122286161-904c6a80-cebd-11eb-85ac-2d82fd2e0867.png)