### PR TITLE
Removed Right Align and Fixed With of Inputs.

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -678,7 +678,6 @@ div.field {
     right: 10px;
   }
   width: 150px;
-  text-align: right;
   flex-shrink: 0;
 
   .field_with_errors {
@@ -708,7 +707,8 @@ div.field {
     }
   }
 
-  [type="text"] {
+  [type="text"],
+  [type="password"] {
     min-width: 300px;
   }
 }

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -9,12 +9,16 @@
 
   %fieldset
     .field.flex
+      %div.field-key
+        = f.label :email
       %div.field-value
-        = f.text_field :email, :tabindex => 1, :placeholder => 'Email'
+        = f.text_field :email, :tabindex => 1
 
     .field.flex
+      %div.field-key
+        = f.label :password
       %div.field-value
-        = f.password_field :password, :tabindex => 2, :placeholder => 'Password'
+        = f.password_field :password, :tabindex => 2
 
     - if devise_mapping.rememberable?
       .field.flex

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -8,13 +8,13 @@
   = hidden_field_tag 'user[year]', @year.year
 
   %fieldset
-    .field.flex
+    .field
       %div.field-key
         = f.label :email
       %div.field-value
         = f.text_field :email, :tabindex => 1
 
-    .field.flex
+    .field
       %div.field-key
         = f.label :password
       %div.field-value

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -9,16 +9,12 @@
 
   %fieldset
     .field.flex
-      %div.field-key
-        = f.label :email
       %div.field-value
-        = f.text_field :email, :tabindex => 1
+        = f.text_field :email, :tabindex => 1, :placeholder => 'Email'
 
     .field.flex
-      %div.field-key
-        = f.label :password
       %div.field-value
-        = f.password_field :password, :tabindex => 2
+        = f.password_field :password, :tabindex => 2, :placeholder => 'Password'
 
     - if devise_mapping.rememberable?
       .field.flex


### PR DESCRIPTION
## Summary
The Sign In Page currently aligns each label to the right. Cleans up Sign In Display.

This change removes that and assures that the password and
text input boxes are the same width.

## Screenshots

### Current
![Screenshot from 2021-06-18 17-22-45](https://user-images.githubusercontent.com/5054653/122625408-dd654380-d059-11eb-8065-c4f2deaa549a.png)

### Updated
![Screenshot from 2021-06-18 17-20-23](https://user-images.githubusercontent.com/5054653/122625407-db02e980-d059-11eb-8f94-05801079a546.png)