### PR TITLE
Only show confirmed users

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -19,7 +19,7 @@ class ReportsController < ApplicationController
   end
 
   def invoices
-    users = User.yr(@year).to_a
+    users = User.yr(@year).confirmed.to_a
     @user_count = users.count
     @invoice_total_across_all_users = users.map(&:get_invoice_total).reduce(:+)
   end
@@ -48,7 +48,7 @@ class ReportsController < ApplicationController
     min = params[:min].downcase
     max = params[:max].downcase
     [min, max].each { |m| raise "Invalid param" unless ("a".."z").cover?(m) }
-    @users = User.yr(@year).email_range(min, max).order(:email).to_a
+    @users = User.yr(@year).confirmed.email_range(min, max).order(:email).to_a
     render :layout => "print"
   end
 

--- a/app/controllers/rpt/attendee_reports_controller.rb
+++ b/app/controllers/rpt/attendee_reports_controller.rb
@@ -4,7 +4,7 @@ class Rpt::AttendeeReportsController < Rpt::AbstractReportController
     respond_to do |format|
       format.html do
         @attendee_count = @attendees.count
-        @user_count = User.yr(@year).count
+        @user_count = User.yr(@year).confirmed.count
         @cancelled_attendee_count = Attendee.yr(@year).attendee_cancelled.count
         @planless_attendee_count = Attendee.yr(@year).planless.count
         @planful_attendee_count = Attendee.yr(@year).count - @planless_attendee_count

--- a/app/controllers/rpt/attendeeless_user_reports_controller.rb
+++ b/app/controllers/rpt/attendeeless_user_reports_controller.rb
@@ -1,6 +1,6 @@
 class Rpt::AttendeelessUserReportsController < Rpt::AbstractReportController
   def show
-    users = User.yr(@year).attendeeless.select(:email)
+    users = User.yr(@year).confirmed.attendeeless.select(:email)
     @email_list = users.map(&:email).join(', ')
   end
 end

--- a/app/controllers/rpt/cost_summary_reports_controller.rb
+++ b/app/controllers/rpt/cost_summary_reports_controller.rb
@@ -2,7 +2,7 @@ class Rpt::CostSummaryReportsController < Rpt::AbstractReportController
   def show
     respond_to do |format|
       format.html do
-        @user_count = User.yr(@year).count
+        @user_count = User.yr(@year).confirmed.count
         @attendee_count = Attendee.yr(@year).count
       end
       format.csv do

--- a/app/controllers/rpt/outstanding_balance_reports_controller.rb
+++ b/app/controllers/rpt/outstanding_balance_reports_controller.rb
@@ -2,7 +2,7 @@ class Rpt::OutstandingBalanceReportsController < Rpt::AbstractReportController
   def show
     # When generating invoices for multiple users, the `includes`
     # can really speed things up.
-    @users = User.yr(@year).includes([
+    @users = User.yr(@year).confirmed.includes([
       {
         :attendees => [
           { :attendee_activities => :activity },

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
     else
       sort_order = "role = 'A' desc, role = 'S' desc"
     end
-    @users = @users.yr(@year).order(Arel.sql(sort_order)).includes(:attendees)
+    @users = @users.yr(@year).confirmed.order(Arel.sql(sort_order)).includes(:attendees)
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,8 +60,14 @@ class User < ApplicationRecord
     where("(select count(*) from attendees a where a.user_id = users.id) = 0")
   }
 
+  # Class Methods
+  # -------------
   def self.email_range min, max
     where('lower(substr(email, 1, 1)) between ? and ?', min, max)
+  end
+
+  def self.confirmed
+    where.not(:confirmed_at => nil)
   end
 
   # Instance Methods

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -11,7 +11,13 @@ RSpec.describe UsersController, :type => :controller do
   render_views
 
   let(:user) { create :user }
-  let(:user_attributes) { { :email => "test@example.com", :password => "password", :password_confirmation => "password" } }
+  let(:user_attributes) {
+    {
+      :email => "test@example.com",
+      :password => "password",
+      :password_confirmation => "password"
+    }
+  }
   let(:wrong_year) { user.year - 1 }
   let(:year) { Time.zone.now.year }
 


### PR DESCRIPTION
In every area of the site at present, we only want to show confirmed
users on the UI side. Unconfirmed users, who have not confirmed their
email addresses and cannot, therefore, interact with the site in any way
or be contacted, should be ignored.