### PR TITLE
Changed language to express search-ratings is now the American Go Games Database.

### DIFF
--- a/app/views/registrations/_player_info.html.haml
+++ b/app/views/registrations/_player_info.html.haml
@@ -9,8 +9,9 @@
 
 .dialog#dialog_rank{:title => "What is my AGA Rank?"}
   %p
-    If you have played in AGA tournaments, you can look up your rank
-    = link_to 'here.', 'http://usgo.org/search-ratings', :target => '_blank'
+    If you have played in AGA tournaments, you can look up your rank on the
+    = link_to 'American Go Games Database (AGAGD)', 'http://agagd.usgo.org', :target => '_blank'
+    website application.
   %p
     If you are not sure of your AGA rating or
     rank, but know your rating from another system, please consult


### PR DESCRIPTION
## Summary
Resolves #246

## Note
-  http://usgo.org/search-ratings now redirects to https://agagd.usgo.org.
