### PR TITLE
Change activity notes field to "text" type without character limit

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -9,10 +9,6 @@ class Activity < ApplicationRecord
   validates :activity_category, :presence => true
   validates_presence_of :leave_time, :name, :return_time
   validates :location, :length => { :maximum => 50 }
-  validates :notes, :length => {
-    :maximum => 2000,
-    :message => "are too long (maximum is 2000 characters)"
-  }
   validates :phone, :length => { :maximum => 20 }
   validates :price, :numericality => {
     :equal_to => 0,

--- a/db/migrate/20210701195219_remove_activities_notes_length_limit.rb
+++ b/db/migrate/20210701195219_remove_activities_notes_length_limit.rb
@@ -1,0 +1,5 @@
+class RemoveActivitiesNotesLengthLimit < ActiveRecord::Migration[6.0]
+  def change
+    change_column :activities, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_025357) do
+ActiveRecord::Schema.define(version: 2021_07_01_195219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2021_06_30_025357) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "leave_time"
-    t.string "notes", limit: 2000
+    t.text "notes"
     t.time "return_time"
     t.integer "year", null: false
     t.string "location", limit: 50


### PR DESCRIPTION
The only real reason to have a limit is to keep things that are in the
registration workflow sane for users, but we already cut this
description off in the registration form and offer a "more" button to
link to the full activity. That means the activity really can be as long
as it wants.

This changes the field from a string type (which requires a character
limit) to a text type, which does not.

@see:
https://stackoverflow.com/questions/8694273/changing-a-column-type-to-longer-strings-in-rails

Closes #259