### PR TITLE
Add email lists of registered attendees to tournament reports

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@ only has autocomplete, datepicker, and dialog. -Jared 2012-07-09 */
 //= require intlTelInput
 //= require libphonenumber/utils
 //= require editable_texts
+//= require email_lists
 
 /* TODO: We only need the galleria stuff on the homepage. Hiding
 this on other pages could improve page speed -Jared 2011.2.3 */

--- a/app/assets/javascripts/email_lists.js
+++ b/app/assets/javascripts/email_lists.js
@@ -1,0 +1,51 @@
+document.addEventListener("DOMContentLoaded", function () {
+  // Find any elements marked with the "email-list" class and add standard email
+  // list controls to them
+  const emailLists = document.querySelectorAll(".email-list");
+  emailLists.forEach(setUpEmailList);
+});
+
+function setUpEmailList(list) {
+  const textarea = list.querySelector("textarea");
+
+  // Create the necessary DOM elements
+  const controls = document.createElement("div");
+  controls.classList.add("controls");
+
+  const separatorControl = document.createElement("label");
+  separatorControl.classList.add("separator-control");
+  separatorControl.innerText = "Separator: ";
+
+  const separatorInput = document.createElement("input");
+  separatorInput.type = "text";
+  separatorInput.value = ", ";
+  separatorControl.appendChild(separatorInput);
+
+  // When the separator input value changes, substitute the separator in the
+  // list of emails so that clients that have different requirements (such as
+  // semi-colons) can easily adjust their list
+  separatorInput.addEventListener("keyup", () => {
+    textarea.value = textarea.dataset.emails.replace(
+      /, /g,
+      separatorInput.value
+    );
+  });
+
+  const copyButton = document.createElement("button");
+  copyButton.innerText = "Copy";
+  copyButton.classList.add("copy");
+
+  // Copy the email list to the clipboard when this button is clicked
+  copyButton.addEventListener("click", async (event) => {
+    const button = event.currentTarget;
+    button.classList.remove("copied");
+    await navigator.clipboard.writeText(textarea.value);
+    button.innerText = "Copied";
+    button.classList.add("copied");
+  });
+
+  controls.appendChild(separatorControl);
+  controls.appendChild(copyButton);
+
+  list.appendChild(controls);
+}

--- a/app/assets/stylesheets/email_lists.scss
+++ b/app/assets/stylesheets/email_lists.scss
@@ -1,0 +1,33 @@
+// Place all the styles related to the EditableTexts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/
+
+.email-list {
+  width: 100%;
+  max-width: 600px;
+  textarea {
+    box-sizing: border-box;
+    height: 200px;
+    width: 100%;
+  }
+
+  .controls {
+    display: flex;
+  }
+
+  .separator-control {
+    margin-right: auto;
+    input {
+      width: 25px;
+    }
+  }
+
+  button {
+    &.copied {
+      background-color: green;
+      &:after {
+        content: ' ✓'
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -13,6 +13,7 @@
 @import "jquery_ui_tweaks";
 @import "_shirt_colors";
 @import "editable_texts";
+@import "email_lists";
 
 @import "stripe";
 

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -225,6 +225,10 @@ class Attendee < ApplicationRecord
     respect_anonymity ? anonymize(name) : name
   end
 
+  def formatted_email
+    "\"#{self.full_name}\" <#{self.email}>"
+  end
+
   def plan_count
     plans.count
   end

--- a/app/views/rpt/tournament_reports/show.html.haml
+++ b/app/views/rpt/tournament_reports/show.html.haml
@@ -40,3 +40,8 @@
 %p Import into OpenGotha by selecting <strong>Tournament &rarr; Import &hellip; &rarr; Import Tournament From XML File</strong>.
 = form_tag(xml_path, :method => :get) do
   %p= submit_tag "Export"
+
+%h3 Registered Attendee Emails
+.email-list
+  %textarea#attendee_emails{:'data-emails' => @players.map { |p| p.formatted_email }.join(', ')}
+    = @players.map { |p| p.formatted_email }.join(', ')


### PR DESCRIPTION
Also creates a standard "email-list" element that can be used anywhere
that enhances a textarea with separator changer (different clients need
different separators) and a copy-to-clipboard button.

![2021-07-02 at 11 52 PM](https://user-images.githubusercontent.com/176993/124342262-a716e080-db90-11eb-9c4b-29c008e74f95.png)

Closes #261 