### PR TITLE
Fix Registration#attendee_number

### DIFF
--- a/app/forms/registration.rb
+++ b/app/forms/registration.rb
@@ -102,8 +102,11 @@ class Registration
     form_plans.group_by(&:plan_category)
   end
 
+  # At the top of `registrations/new`, we say "First Attendee",
+  # "Second Attendee", etc. If you are filling out the form for your second
+  # attendee, it should say "Second Attendee".
   def attendee_number
-    @attendee.user.uncanceled_attendees.length
+    @attendee.user.uncanceled_attendees.length + 1
   end
 
   private


### PR DESCRIPTION
The definition was changed in 5f1195b0e5b40db45e2d6e69a58570f84684bd41,
which broke two tests, e.g. registrations_controller_spec.rb:73

I believe the change was incorrect, as explained in my comment. So,
this commit reverts that change. This is a *partial* reversion of
5f1195b0e5b40db45e2d6e69a58570f84684bd41. The other parts are not
familiar to me (I don't know what "canceling" an attendee means)
so I left them as is.