### PR TITLE
Fix daily plan selections

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -417,36 +417,41 @@ body {
 
   button {
     background: $nav-bg-color;
-    line-height: 25px;
   }
 
   li {
     display: inline-block;
     list-style: none;
-    // text-align: center;
+
     &#nav-admin-title {
       padding: 5px 10px;
     }
+
     &#nav-registration a {
       color: #ff2;
     }
+
     a {
       display: inline-block;
       padding: 5px $spacing-unit / 3;
       color: $nav-link-color;
-      line-height: 25px;
       text-decoration: none;
       background-color: transparent;
       transition: background-color 0.2s;
+
       &:hover {
         background-color: $nav-bg-highlight-color;
       }
     }
   }
+
+  button, li > a {
+    padding-top: 8px;
+    padding-bottom: 9px;
+  }
 }
 #nav-list-main {
   margin: 0 auto;
-  // max-width: $content_width;
 }
 
 /* Secondary navigation */
@@ -461,7 +466,6 @@ body {
 .content {
   margin: 0 auto;
   padding: $spacing-unit;
-  // width: $content_width;
 
   /* Drawing extra attention to various things */
   .notice {

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -67,6 +67,11 @@ table.semantic {
   thead th {
     vertical-align: bottom;
   }
+  td > input[type=checkbox] {
+    margin: {
+      top: 0.2em;;
+    }
+  }
   td,
   th {
     border: 0;

--- a/app/helpers/attendee_helper.rb
+++ b/app/helpers/attendee_helper.rb
@@ -21,9 +21,9 @@ module AttendeeHelper
     checked = selection.qty == 1
     title = "Select this " + mnh
     if plan.disabled? && !current_user_is_admin?
-      check_box_tag qty_field_name(plan), 1, checked, :disabled => true
+      check_box_tag qty_field_name(plan), 1, checked, :id => qty_field_name(plan), :disabled => true
     else
-      check_box_tag qty_field_name(plan), 1, checked, :title => title
+      check_box_tag qty_field_name(plan), 1, checked, :title => title, :id => qty_field_name(plan)
     end
   end
 
@@ -74,6 +74,10 @@ module AttendeeHelper
 
   def qty_field_name(plan)
     "plans[#{plan.id}][qty]"
+  end
+
+  def qty_field_id(plan)
+    "plan_#{plan.id}_qty"
   end
 
   def radio_btn_name(plan)

--- a/app/views/plan_categories/_plan_table_common_cells.html.haml
+++ b/app/views/plan_categories/_plan_table_common_cells.html.haml
@@ -1,10 +1,10 @@
-%td
+%td.valign-top
   %label{for: plan_label_name(plan)}= plan.age_range_in_words
-%td
+%td.valign-top
   %label{for: plan_label_name(plan)}
     = markdown(plan.description).html_safe
 - if @show_availability
-  %td
+  %td.valign-top
     %label{for: plan_label_name(plan)}= plan.describe_inventory_available
-%td.numeric
+%td.numeric.valign-top
   %label{for: plan_label_name(plan)}= plan.price_for_display

--- a/app/views/plan_categories/_plan_table_plan_row.html.haml
+++ b/app/views/plan_categories/_plan_table_plan_row.html.haml
@@ -1,15 +1,15 @@
 - if defined? plan
   %tr{:class => if plan.disabled? then "disabled" end}
-    %td.valign-middle.align-right
+    %td.valign-top.align-right
       = plan_selection_inputs(plan)
-    %td
+    %td.valign-top
       %label{for: plan_label_name(plan)}= plan.name
     = render :partial => "plan_categories/plan_table_common_cells", :locals => { :plan => plan }
 - else
   -# If no plan is provided, provide a "no selection" radio button
   %tr
-    %td.valign-middle.align-right
+    %td.valign-top.align-right
       = radio_button_tag "plans[single_plan_cat_id:#{category.id}][plan_id]", '', plan_category_selection(category).blank? ? true : false, :title => "Select None"
-    %td{:colspan => 5}
+    %td.valign-top{:colspan => 5}
       %label{for: "plans_single_plan_cat_id:#{category.id}_plan_id_"}
         No Selection

--- a/app/views/shared/_plan_date_fields.haml
+++ b/app/views/shared/_plan_date_fields.haml
@@ -1,4 +1,8 @@
-%table.understated-head.mini-calendar.borderless
+%table.understated-head.mini-calendar.borderless{
+  "data-plan-category": plan.plan_category_id,
+  "data-plan": plan.id,
+  :class => plan.plan_category.single ? 'single' : 'not-single'
+}
   %tbody
     - first_clndr_date = true
     - @plan_calendar.each do |week|
@@ -18,6 +22,41 @@
         = button_tag('Clear', type: 'button', name: 'clear_' + @cbx_name)
 
 :javascript
+  window.addEventListener('DOMContentLoaded', () => {
+    const calendar = document.querySelector('[data-plan-category="#{plan.plan_category.id}"][data-plan="#{plan.id}"].single');
+
+    if (calendar) {
+      // When daily plan checkboxes are selected, clear any other plan radio inputs that have been selected
+      calendar.addEventListener('change', event => {
+        if (event.target.type === 'checkbox') {
+          // Using the array method "some" relies on an array, not a NodeList 
+          const calendarCheckBoxes = Array.from(calendar.querySelectorAll('input[type="checkbox"]'));
+          const anyChecked = calendarCheckBoxes.some(checkbox => checkbox.checked);
+
+          if (anyChecked) {
+            const otherSelectedPlans = document.querySelectorAll('[name="plans[single_plan_cat_id:#{plan.plan_category.id}][plan_id]"]:checked');
+            if (otherSelectedPlans) {
+              otherPlans.forEach(otherPlan => otherPlan.checked = false);
+            }
+          }
+        }
+      });
+
+      // When any of the other plans in this single-plan-only plan category are
+      // selected, clear any of the checkboxes for this daily plan
+      const otherPlans = document.querySelectorAll('[name="plans[single_plan_cat_id:#{plan.plan_category.id}][plan_id]"]');
+
+      otherPlans.forEach(plan => {
+        plan.addEventListener('change', event => {
+          if (event.target.checked) {
+            const calendarCheckBoxes = calendar.querySelectorAll('input[type="checkbox"]');
+            calendarCheckBoxes.forEach(checkbox => checkbox.checked = false);
+          }
+        });
+      });
+    }
+  })
+
   $("[name='setAll_#{@cbx_name}']").click(function() {
     $("[name='#{@cbx_name}']").each(function(i, checkbox) {
       if (!this.checked) {


### PR DESCRIPTION
Add JS to manage exactly-one-plan plan categories

    In a plan category that is single-select ("exactly one plan"):

    * When a user selects an item in a daily plan, uncheck any other plans
      that have been selected

    * When a user selects another plan, uncheck any daily-plan checkboxes
      that have been checked

Fixes #291 