### PR TITLE
Fix Sorting Who is Coming by state

### DIFF
--- a/app/models/attendee/who_is_coming.rb
+++ b/app/models/attendee/who_is_coming.rb
@@ -7,7 +7,7 @@
 
 class Attendee::WhoIsComing < ApplicationController
   DEFAULT_ORDER = 'rank = 0, rank desc'
-  SORTABLE_COLUMNS = %w[given_name family_name rank created_at country]
+  SORTABLE_COLUMNS = %w[given_name family_name rank state created_at country]
 
   attr_reader :attendees
 


### PR DESCRIPTION
Fix the "Who is coming" tab to be able to sort by state.

Now when someone clicks on "State" in the Who is coming tab, it will sort the states in alphabetical order.  